### PR TITLE
TOOLS-28 cr outs take file

### DIFF
--- a/scripts/cellranger_outs_reader.py
+++ b/scripts/cellranger_outs_reader.py
@@ -95,9 +95,9 @@ def getArgs():
 		formatter_class=argparse.RawDescriptionHelpFormatter,
 	)
 	parser.add_argument('--dir', '-d',
-						help="s3 path to the cellranger outs directory")
+						help="s3 path to the cellranger outs directory or local path to a file that lists directories")
 	parser.add_argument('--assay', '-a',
-						help="use if pulling metrics from rna data")
+						help="specify atac or rna")
 	parser.add_argument('--mode', '-m',
 						help='The machine to pull schema from.')
 	args = parser.parse_args()


### PR DESCRIPTION
enable the --dir input to be a local file that contains a directory per line - will cycle through each directory and get metrics for each
separated the code a little per assay still, and specify the assay in the output file names so you won’t overwrite one if you run atac & rna back-to-back
refactored the code a bit to simplify it, and use pandas
now will only spit out one row of headers, not one per directory
now will not error on an s3 uri, but will remove the s3:// and handle it