### PR TITLE
Tools 102 easier added fields

### DIFF
--- a/scripts/flattener.py
+++ b/scripts/flattener.py
@@ -338,8 +338,6 @@ def get_value(obj, prop):
 		key1 = path[0]
 		key2 = path[1]
 		if isinstance(obj.get(key1), list):
-			print(key1)
-			print(obj[key1])
 			values = [i.get(key2, unreported_value) for i in obj[key1]]
 			return list(set(values))
 		elif obj.get(key1):
@@ -1130,7 +1128,7 @@ def main(mfinal_id):
 		
 		# Add anndata to list of final raw anndatas, only for RNAseq
 		if summary_assay in ['RNA','CITE']:
-			###download_file(mxr, tmp_dir)
+			download_file(mxr, tmp_dir)
 			if mfinal_obj.get('spatial_s3_uri', None) and mfinal_obj['assays'] == ['spatial transcriptomics']:
 				if mxr['s3_uri'].endswith('h5'):
 					mxr_name = '{}.h5'.format(mxr_acc)

--- a/scripts/flattener.py
+++ b/scripts/flattener.py
@@ -180,7 +180,7 @@ cxg_obs = None
 
 EPILOG = '''
 Examples:
-HsapDv:0000264
+
     python %(prog)s -m local -f LATDF119AAA
 
 For more details:

--- a/scripts/flattener.py
+++ b/scripts/flattener.py
@@ -33,6 +33,7 @@ cell_metadata = {
 		'age_display',
 		'sex',
 		'summary_ethnicity',
+		'causes_of_death.term_name',
 		'diseases.term_id',
 		'diseases.term_name',
 		'family_medical_history',
@@ -143,6 +144,7 @@ prop_map = {
 	'donor_age_display': 'donor_age',
 	'donor_risk_score_tyrer_cuzick_lifetime': 'tyrer_cuzick_lifetime_risk',
 	'donor_smoker': 'donor_smoking_status',
+	'donor_causes_of_death_term_name': 'donor_cause_of_death',
 	'matrix_description': 'title',
 	'matrix_default_embedding': 'default_embedding',
 	'matrix_is_primary_data': 'is_primary_data',
@@ -925,6 +927,7 @@ def clean_obs():
 		if field in cxg_obs.columns:
 			cxg_obs[field] = cxg_obs[field].astype(str) + " " + cxg_obs[add_units[field]].astype(str)
 			cxg_obs.drop(columns=add_units[field], inplace=True)
+			cxg_obs[field].replace({'unknown unknown': 'unknown'}, inplace=True)
 
 	make_numeric = ['suspension_percent_cell_viability','donor_BMI_at_collection']
 	for field in make_numeric:
@@ -936,7 +939,7 @@ def clean_obs():
 			else: 
 				cxg_obs[field]  = cxg_obs[field].astype('float')
 
-	change_unreported = ['suspension_enriched_cell_types', 'suspension_enrichment_factors', 'suspension_depletion_factors', 'disease_state', 'cell_state']
+	change_unreported = ['suspension_enriched_cell_types','suspension_depleted_cell_types','suspension_enrichment_factors','suspension_depletion_factors','disease_state','cell_state']
 	for field in change_unreported:
 		if field in cxg_obs.columns.to_list():
 			cxg_obs[field].replace({unreported_value: 'na'}, inplace=True)
@@ -959,7 +962,7 @@ def drop_cols(celltype_col):
 			'donor_living_at_sample_collection','donor_menopausal_status','donor_smoking_status','sample_derivation_process','suspension_dissociation_reagent',\
 			'suspension_dissociation_time','suspension_depleted_cell_types','suspension_derivation_process','suspension_percent_cell_viability',\
 			'library_starting_quantity','library_starting_quantity_units','tissue_handling_interval','suspension_dissociation_time_units','alignment_software',\
-			'mapped_reference_annotation','mapped_reference_assembly','sequencing_platform', 'sample_source']
+			'mapped_reference_annotation','mapped_reference_assembly','sequencing_platform','sample_source','donor_cause_of_death']
 	
 	if 'sequencing_platform' in cxg_obs.columns:
 		if cxg_obs['sequencing_platform'].isnull().values.any():
@@ -1385,7 +1388,6 @@ def main(mfinal_id):
 		add_labels()
 		map_antibody()
 		add_zero()
-
 	
 	if not sparse.issparse(cxg_adata_raw.X):
 		cxg_adata_raw = ad.AnnData(X = sparse.csr_matrix(cxg_adata_raw.X), obs = cxg_adata_raw.obs, var = cxg_adata_raw.var)

--- a/scripts/flattener.py
+++ b/scripts/flattener.py
@@ -1309,7 +1309,10 @@ def main(mfinal_id):
 	cxg_obs = pd.merge(cxg_obs, mfinal_adata.obs[[celltype_col]], left_index=True, right_index=True, how='left')
 	cxg_obs = pd.merge(cxg_obs, annot_df, left_on=celltype_col, right_index=True, how='left')
 	if cxg_obs['cell_type_ontology_term_id'].isnull().values.any():
-		print("WARNING: There are cells that did not sucessfully map to CellAnnotations:")
+		print("\nWARNING: Cells did not sucessfully map to CellAnnotations with author cell type and counts: {}".\
+			format(cxg_obs.loc[cxg_obs['cell_type_ontology_term_id'].isnull()==True, celltype_col].value_counts().to_dict()))
+	if len([i for i in annot_df.index.to_list() if i not in cxg_obs[celltype_col].unique().tolist()]) > 0:
+		print("WARNING: CellAnnotation that is unmapped: {}\n".format([i for i in annot_df.index.to_list() if i not in cxg_obs[celltype_col].unique().tolist()]))
 
 	if 'author_cluster_column' in mfinal_obj:
 		cluster_col = mfinal_obj['author_cluster_column']


### PR DESCRIPTION
This version of the flattener corresponds with [this comment](https://lattice.atlassian.net/browse/TOOLS-102?focusedCommentId=15857) in TOOL-102, with the following additions:

- Fix for cell identifier logging error (where RawMatrixFiles without associate prefix/suffix, such as Slide-seq) are taken into consideration
- HumanPostnatalDonor.living_at_sample_collection (donor_living_at_sample_collection)
- HumanPostnatalDonor.menopausal_status (donor_menapausal_status)
- HumanPostnatalDonor.smoker (donor_smoking_status)
- Tissue.derivation_process (sample_derivation_process)
- Suspension.dissociation_reagent (suspension_dissociation_reagent)
- Suspension.dissociation_time/Suspension.dissociation_time_units (suspension_dissociation_time)
- Suspension.depleted_cell_types (suspension_depleted_cell_types)
- Suspension.derivation_process (suspension_derivation_process)
- Suspension.percent_cell_viability (suspension_percent_cell_viability)
- Suspension.tissue_handling_interval (tissue_handling_interval)
- Library.starting_quantity/Library.starting_quantity_units (library_starting_quantity)
- SequencingRun.platform
- RawMatrixFile.assembly
- RawMatrixFile.software
- Tissue.source

Related tickets that have recently gotten in that should also be taken into consideration:
- Convert bmi to numeric: https://lattice.atlassian.net/browse/TOOLS-124
- Cell identifiers and annotation logging: https://lattice.atlassian.net/browse/TOOLS-125

Would be great to have a thorough code review and testing. @jahilton @Jchaffer787, not sure what people's bandwidth are or best plan of action. I can update this ticket later with a list of ProcMatrixFiles to run? Should I start up EC2?
