### PR TITLE
Adding check and fix for tissue_positions.csv

### DIFF
--- a/scripts/flattener.py
+++ b/scripts/flattener.py
@@ -1138,6 +1138,12 @@ def main(mfinal_id):
 				elif mxr['s3_uri'].endswith('h5ad'):
 					mxr_name = '{}.h5ad'.format(mxr_acc)
 				download_directory(mfinal_obj['spatial_s3_uri'], tmp_dir)
+				# If tissue_positions is present rename to tissue_positions_list and remove header
+				tiss_positions_check = os.path.exists(tmp_dir + '/spatial/tissue_positions.csv')
+				if tiss_positions_check == True:
+					fixed_file = pd.read_csv(tmp_dir + '/spatial/tissue_positions.csv', header = 1)
+					fixed_file.to_csv(tmp_dir + '/spatial/tissue_positions_list.csv')
+					os.remove(tmp_dir + '/spatial/tissue_positions.csv'
 				if 'spatial' in mfinal_adata.uns.keys():
 					del mfinal_adata.uns['spatial']
 				adata_raw = sc.read_visium(tmp_dir, count_file=mxr_name)


### PR DESCRIPTION
Code added first checks for the presence of tissue_positions.csv in tmp_dir. If present, reads in tissue_positions while simultaneously removing header, and then saves file in same location in tmp_dir but with correct name (tissue_positions_list.csv). Original tissue_positions.csv file is then removed from tmp_dir.