### PR TITLE
Tools 127 replace deprecated concatenate append

### DIFF
--- a/scripts/flattener.py
+++ b/scripts/flattener.py
@@ -782,14 +782,14 @@ def reconcile_genes(cxg_adata_lst):
 	for cxg_adata in cxg_adata_lst:
 		cxg_adata.var['gene_symbols'] = cxg_adata.var.index
 		cxg_adata.var = cxg_adata.var.set_index('gene_ids', drop=True)
-	cxg_adata_raw_ensembl = cxg_adata_lst[0].concat(cxg_adata_lst[1:], index_unique=None, joint='outer')
+	cxg_adata_raw_ensembl = ad.concat([cxg_adata_lst[0],cxg_adata_lst[1:]], index_unique=None, joint='outer')
 
 	# Join raw matrices on gene symbol, ensembl stored as metadata. Add suffix to make unique, using '.' as to match R default
 	for cxg_adata in cxg_adata_lst:
 		cxg_adata.var['gene_ids'] = cxg_adata.var.index
 		cxg_adata.var =  cxg_adata.var.set_index('gene_symbols', drop=True)
 		cxg_adata.var_names_make_unique(join = '.')
-	cxg_adata_raw_symbol = cxg_adata_lst[0].concat(cxg_adata_lst[1:], index_unique=None, join='outer')
+	cxg_adata_raw_symbol = ad.concat([cxg_adata_lst[0],cxg_adata_lst[1:]], index_unique=None, join='outer')
 
 	# Go through adata indexed on symbol to see which have > 1 Ensembl ID
 	gene_pd_symbol = cxg_adata_raw_symbol.var[[i for i in cxg_adata_raw_symbol.var.columns.values.tolist() if 'gene_ids' in i]]
@@ -1250,7 +1250,7 @@ def main(mfinal_id):
 			logging.info('drop_all_removes:\t{}\t{}'.format(len(drop_removes), drop_removes))
 			mfinal_adata = mfinal_adata[:, [i for i in mfinal_adata.var.index.to_list() if i not in all_remove]]
 		else:
-			cxg_adata_raw = cxg_adata_lst[0].concat(cxg_adata_lst[1:],index_unique=None, join='outer', uns_merge='first')
+			cxg_adata_raw = ad.concat([cxg_adata_lst[0],cxg_adata_lst[1:]],index_unique=None, join='outer', uns_merge='first')
 			if len(feature_lengths) == 1:
 				if cxg_adata_raw.var.shape[0] != feature_lengths[0]:
 					sys.exit('There should be the same genes for raw matrices if only a single genome annotation')
@@ -1258,7 +1258,7 @@ def main(mfinal_id):
 		if cxg_adata_raw.shape[0] != mfinal_adata.shape[0]:
 			sys.exit('The number of cells do not match between final matrix and cxg h5ad.')
 	elif summary_assay == 'CITE':
-		cxg_adata_raw = cxg_adata_lst[0].concat(cxg_adata_lst[1:], index_unique=None, join='outer')
+		cxg_adata_raw = ad.concat([cxg_adata_lst[0],cxg_adata_lst[1:]], index_unique=None, join='outer')
 		if len(feature_lengths) == 1:
 			if cxg_adata_raw.var.shape[0] != feature_lengths[0]:
 				sys.exit('There should be the same genes for raw matrices if only a single genome annotation')

--- a/scripts/flattener.py
+++ b/scripts/flattener.py
@@ -668,7 +668,7 @@ def demultiplex(lib_donor_df, library_susp, donor_susp):
 		 	else: 
 		 		print('ERROR: Could not find suspension for demultiplexed donor: {}'.format(obj_type))
 		row_to_add = pd.Series(values_to_add)
-		susp_df = susp_df.append(row_to_add, ignore_index=True)
+		susp_df = pd.concat([susp_df,row_to_add], ignore_index=True)
 	lib_donor_df = lib_donor_df.merge(susp_df, left_on='suspension_@id', right_on='suspension_@id', how='left')
 	return(lib_donor_df)
 
@@ -782,14 +782,14 @@ def reconcile_genes(cxg_adata_lst):
 	for cxg_adata in cxg_adata_lst:
 		cxg_adata.var['gene_symbols'] = cxg_adata.var.index
 		cxg_adata.var = cxg_adata.var.set_index('gene_ids', drop=True)
-	cxg_adata_raw_ensembl = cxg_adata_lst[0].concatenate(cxg_adata_lst[1:], index_unique=None, join='outer')
+	cxg_adata_raw_ensembl = cxg_adata_lst[0].concat(cxg_adata_lst[1:], index_unique=None, joint='outer')
 
 	# Join raw matrices on gene symbol, ensembl stored as metadata. Add suffix to make unique, using '.' as to match R default
 	for cxg_adata in cxg_adata_lst:
 		cxg_adata.var['gene_ids'] = cxg_adata.var.index
 		cxg_adata.var =  cxg_adata.var.set_index('gene_symbols', drop=True)
 		cxg_adata.var_names_make_unique(join = '.')
-	cxg_adata_raw_symbol = cxg_adata_lst[0].concatenate(cxg_adata_lst[1:], index_unique=None, join='outer')
+	cxg_adata_raw_symbol = cxg_adata_lst[0].concat(cxg_adata_lst[1:], index_unique=None, join='outer')
 
 	# Go through adata indexed on symbol to see which have > 1 Ensembl ID
 	gene_pd_symbol = cxg_adata_raw_symbol.var[[i for i in cxg_adata_raw_symbol.var.columns.values.tolist() if 'gene_ids' in i]]
@@ -1250,7 +1250,7 @@ def main(mfinal_id):
 			logging.info('drop_all_removes:\t{}\t{}'.format(len(drop_removes), drop_removes))
 			mfinal_adata = mfinal_adata[:, [i for i in mfinal_adata.var.index.to_list() if i not in all_remove]]
 		else:
-			cxg_adata_raw = cxg_adata_lst[0].concatenate(cxg_adata_lst[1:], index_unique=None, join='outer', uns_merge='first')
+			cxg_adata_raw = cxg_adata_lst[0].concat(cxg_adata_lst[1:],index_unique=None, join='outer', uns_merge='first')
 			if len(feature_lengths) == 1:
 				if cxg_adata_raw.var.shape[0] != feature_lengths[0]:
 					sys.exit('There should be the same genes for raw matrices if only a single genome annotation')
@@ -1258,7 +1258,7 @@ def main(mfinal_id):
 		if cxg_adata_raw.shape[0] != mfinal_adata.shape[0]:
 			sys.exit('The number of cells do not match between final matrix and cxg h5ad.')
 	elif summary_assay == 'CITE':
-		cxg_adata_raw = cxg_adata_lst[0].concatenate(cxg_adata_lst[1:], index_unique=None, join='outer')
+		cxg_adata_raw = cxg_adata_lst[0].concat(cxg_adata_lst[1:], index_unique=None, join='outer')
 		if len(feature_lengths) == 1:
 			if cxg_adata_raw.var.shape[0] != feature_lengths[0]:
 				sys.exit('There should be the same genes for raw matrices if only a single genome annotation')

--- a/scripts/flattener.py
+++ b/scripts/flattener.py
@@ -603,6 +603,18 @@ def clean_list(lst, exp_disease):
 	disease = exp_disease['term_id'] if exp_disease['term_id'] in lst else 'PATO:0000461'
 	return disease
 
+# Concatenate first object in cxg_adata_lst with rest of the objects in the list
+def concat_list(anndata_obj,anndata_list,uns_merge):
+	if uns_merge == True:
+		concat_result = ad.concat([anndata_obj,anndata_list[0]], index_unique=None, join='outer', merge = 'first', uns_merge='first')
+		for a in anndata_list[1:]:
+			concat_result = ad.concat([concat_result,a],index_unique=None, join='outer', merge = 'first',  uns_merge='first')
+		return concat_result
+	else:
+		concat_result = ad.concat([anndata_obj,anndata_list[0]],index_unique=None, merge = 'first', join='outer')
+		for a in anndata_list[1:]:
+			concat_result = ad.concat([concat_result,a],index_unique=None, merge = 'first', join='outer')
+		return concat_result
 
 # Determine reported disease as unique of sample and donor diseases, removing unreported value
 def report_diseases(mxr_df, exp_disease):
@@ -668,7 +680,7 @@ def demultiplex(lib_donor_df, library_susp, donor_susp):
 		 	else: 
 		 		print('ERROR: Could not find suspension for demultiplexed donor: {}'.format(obj_type))
 		row_to_add = pd.Series(values_to_add)
-		susp_df = pd.concat([susp_df,row_to_add], ignore_index=True)
+		susp_df = pd.concat([susp_df,row_to_add.to_frame().T], ignore_index=True)
 	lib_donor_df = lib_donor_df.merge(susp_df, left_on='suspension_@id', right_on='suspension_@id', how='left')
 	return(lib_donor_df)
 
@@ -782,14 +794,14 @@ def reconcile_genes(cxg_adata_lst):
 	for cxg_adata in cxg_adata_lst:
 		cxg_adata.var['gene_symbols'] = cxg_adata.var.index
 		cxg_adata.var = cxg_adata.var.set_index('gene_ids', drop=True)
-	cxg_adata_raw_ensembl = ad.concat([cxg_adata_lst[0],cxg_adata_lst[1:]], index_unique=None, joint='outer')
+	cxg_adata_raw_ensembl = concat_list(cxg_adata_lst[0],cxg_adata_lst[1:],False)
 
 	# Join raw matrices on gene symbol, ensembl stored as metadata. Add suffix to make unique, using '.' as to match R default
 	for cxg_adata in cxg_adata_lst:
 		cxg_adata.var['gene_ids'] = cxg_adata.var.index
 		cxg_adata.var =  cxg_adata.var.set_index('gene_symbols', drop=True)
 		cxg_adata.var_names_make_unique(join = '.')
-	cxg_adata_raw_symbol = ad.concat([cxg_adata_lst[0],cxg_adata_lst[1:]], index_unique=None, join='outer')
+	cxg_adata_raw_symbol = concat_list(cxg_adata_lst[0],cxg_adata_lst[1:],False)
 
 	# Go through adata indexed on symbol to see which have > 1 Ensembl ID
 	gene_pd_symbol = cxg_adata_raw_symbol.var[[i for i in cxg_adata_raw_symbol.var.columns.values.tolist() if 'gene_ids' in i]]
@@ -1250,7 +1262,7 @@ def main(mfinal_id):
 			logging.info('drop_all_removes:\t{}\t{}'.format(len(drop_removes), drop_removes))
 			mfinal_adata = mfinal_adata[:, [i for i in mfinal_adata.var.index.to_list() if i not in all_remove]]
 		else:
-			cxg_adata_raw = ad.concat([cxg_adata_lst[0],cxg_adata_lst[1:]],index_unique=None, join='outer', uns_merge='first')
+			cxg_adata_raw = concat_list(cxg_adata_lst[0],cxg_adata_lst[1:],True)
 			if len(feature_lengths) == 1:
 				if cxg_adata_raw.var.shape[0] != feature_lengths[0]:
 					sys.exit('There should be the same genes for raw matrices if only a single genome annotation')
@@ -1258,7 +1270,7 @@ def main(mfinal_id):
 		if cxg_adata_raw.shape[0] != mfinal_adata.shape[0]:
 			sys.exit('The number of cells do not match between final matrix and cxg h5ad.')
 	elif summary_assay == 'CITE':
-		cxg_adata_raw = ad.concat([cxg_adata_lst[0],cxg_adata_lst[1:]], index_unique=None, join='outer')
+		cxg_adata_raw = concat_list(cxg_adata_lst[0],cxg_adata_lst[1:],False)
 		if len(feature_lengths) == 1:
 			if cxg_adata_raw.var.shape[0] != feature_lengths[0]:
 				sys.exit('There should be the same genes for raw matrices if only a single genome annotation')


### PR DESCRIPTION
Added a concat_list function which allows for concatenating a list with Anndata .concat to replace deprecated .concatenate. 
Replaced deprecated .append with .concat, changing row_to_add to a series in order to work.