### PR TITLE
Tools 139 suppressing unnessecary warnings

### DIFF
--- a/scripts/flattener.py
+++ b/scripts/flattener.py
@@ -18,6 +18,7 @@ import logging
 import gc
 from scipy import sparse
 from datetime import datetime
+import warnings
 
 # Reference files by which the flattener will filter var features
 ref_files = {
@@ -1059,6 +1060,10 @@ def main(mfinal_id):
 	# Adding date and time to top of logging file
 	time_date = datetime.now().strftime("%m/%d/%Y %H:%M:%S")
 	logging.info("Date and time of flattener run: " + time_date)
+
+	# Suppressing specific anndata warnings
+	warnings.filterwarnings('ignore',message='Trying to modify attribute `.obs` of view, initializing view as actual.')
+	warnings.filterwarnings('ignore',message='Variable names are not unique. To make them unique, call `.var_names_make_unique`.')
 
 	# confirm that the identifier you've provided corresponds to a ProcessedMatrixFile
 	mfinal_type = mfinal_obj['@type'][0]

--- a/scripts/flattener.py
+++ b/scripts/flattener.py
@@ -18,7 +18,6 @@ import logging
 import gc
 from scipy import sparse
 from datetime import datetime
-import warnings
 
 # Reference files by which the flattener will filter var features
 ref_files = {
@@ -1060,10 +1059,8 @@ def main(mfinal_id):
 	# Adding date and time to top of logging file
 	time_date = datetime.now().strftime("%m/%d/%Y %H:%M:%S")
 	logging.info("Date and time of flattener run: " + time_date)
-
-	# Suppressing specific anndata warnings
-	warnings.filterwarnings('ignore',message='Trying to modify attribute `.obs` of view, initializing view as actual.')
-	warnings.filterwarnings('ignore',message='Variable names are not unique. To make them unique, call `.var_names_make_unique`.')
+	# Suppressing specific warnings from anndata
+	logging.captureWarnings(True)
 
 	# confirm that the identifier you've provided corresponds to a ProcessedMatrixFile
 	mfinal_type = mfinal_obj['@type'][0]


### PR DESCRIPTION
Simple fix, not actually suppressing any warnings, but instead now printing them out exclusively in the logging outfile. This should make the print window much less crowded so that the downloads are easier to follow, while also not losing any important contextual information.