### PR TITLE
Tools 139 updates for schema 4.0

### DIFF
--- a/scripts/flattener.py
+++ b/scripts/flattener.py
@@ -1446,6 +1446,11 @@ def main(mfinal_id):
 	var_meta = mfinal_adata.var.select_dtypes(include=keep_types)
 	cxg_adata = ad.AnnData(mfinal_adata.X, obs=cxg_obs, obsm=cxg_obsm, var=cxg_var, uns=cxg_uns)
 	cxg_adata.var = cxg_adata.var.merge(var_meta, left_index=True, right_index=True, how='left')
+	
+	# Removing feature_length column from var if present
+	if 'feature_length' in cxg_adata.var.columns:
+		adata.var.drop(columns=['feature_length'], inplace=True)
+		
 	if not sparse.issparse(cxg_adata.X):
 		cxg_adata.X = sparse.csr_matrix(cxg_adata.X)
 	elif cxg_adata.X.getformat()=='csc':

--- a/scripts/flattener.py
+++ b/scripts/flattener.py
@@ -472,7 +472,6 @@ def gather_pooled_metadata(obj_type, properties, values_to_add, objs):
 			for i in unknowns:
 				values_df[i] = 'unknown'
 			for index, row in values_df.iterrows():
-				print(row)
 				values_to_add[index] = row
 		else:
 			value = list()

--- a/scripts/flattener.py
+++ b/scripts/flattener.py
@@ -61,7 +61,8 @@ cell_metadata = {
 		'summary_body_mass_index_at_collection',
 		'treatment_summary',
 		'growth_medium',
-		'genetic_modifications'
+		'genetic_modifications',
+		'@type'
 		],
 	'tissue_section': [
 		'uuid',
@@ -350,12 +351,14 @@ def get_value(obj, prop):
 			return list(set(values))
 		elif obj.get(key1):
 			value = obj[key1].get(key2, unreported_value)
-			if key1 == 'biosample_ontology' and 'Culture' in obj['@type']:
+			if key1 == 'biosample_ontology' and 'Biosample' in obj['@type']:
 				obj_type = obj['@type'][0]
 				if obj_type == 'Organoid':
 					obj_type_conv = 'organoid'
 				elif obj_type == 'CellCulture':
 					obj_type_conv = 'cell culture'
+				elif obj_type == 'Tissue':
+					obj_type_conv = 'tissue'
 				return  '{} ({})'.format(value, obj_type_conv)
 			else:
 				return value

--- a/scripts/flattener.py
+++ b/scripts/flattener.py
@@ -342,7 +342,11 @@ def gather_objects(input_object, start_type=None):
 def get_value(obj, prop):
 	path = prop.split('.')
 	if len(path) == 1:
-		return obj.get(prop, unreported_value)
+		if path[0] == '@type':
+			value = obj.get('@type')[0]
+			return value
+		else:
+			return obj.get(prop, unreported_value)
 	elif len(path) == 2:
 		key1 = path[0]
 		key2 = path[1]
@@ -351,17 +355,7 @@ def get_value(obj, prop):
 			return list(set(values))
 		elif obj.get(key1):
 			value = obj[key1].get(key2, unreported_value)
-			if key1 == 'biosample_ontology' and 'Biosample' in obj['@type']:
-				obj_type = obj['@type'][0]
-				if obj_type == 'Organoid':
-					obj_type_conv = 'organoid'
-				elif obj_type == 'CellCulture':
-					obj_type_conv = 'cell culture'
-				elif obj_type == 'Tissue':
-					obj_type_conv = 'tissue'
-				return  '{} ({})'.format(value, obj_type_conv)
-			else:
-				return value
+			return value
 		else:
 			return obj.get(key1,unreported_value)
 	elif len(path) == 3:

--- a/scripts/flattener.py
+++ b/scripts/flattener.py
@@ -1012,6 +1012,8 @@ def clean_obs():
 	valid_tissue_types = ['tissue', 'organoid', 'cell culture']
 	cxg_obs['tissue_type'] = cxg_obs['tissue_type'].str.lower()
 	for i in cxg_obs['tissue_type'].unique().tolist():
+		if i == 'cellculture':
+			cxg_obs['tissue_type'].replace({'cellculture':'cell culture'}, inplace=True)
 		if i not in valid_tissue_types:
 			logging.error('ERROR: not a valid tissue type:\t{}'.format(i))
 			print('ERROR: not a valid tissue type:\t{}'.format(i))
@@ -1535,7 +1537,7 @@ def main(mfinal_id):
 		add_zero()
 
 	# Check that cxg_adata_raw.X is correct datatype
-	if not isinstance(cxg_adata_raw.X, np.float32):
+	if not cxg_adata_raw.X.dtype == 'float32':
 		cxg_adata_raw.X = cxg_adata_raw.X.astype(np.float32)
 
 	if not sparse.issparse(cxg_adata_raw.X):

--- a/scripts/flattener.py
+++ b/scripts/flattener.py
@@ -472,7 +472,7 @@ def gather_pooled_metadata(obj_type, properties, values_to_add, objs):
 			for i in unknowns:
 				values_df[i] = 'unknown'
 			for index, row in values_df.iterrows():
-				values_to_add[index] = row
+				values_to_add[index] = str(row[1])
 		else:
 			value = list()
 			for obj in objs:

--- a/scripts/flattener.py
+++ b/scripts/flattener.py
@@ -1489,7 +1489,7 @@ def main(mfinal_id):
 		cxg_adata.X = sparse.csr_matrix(cxg_adata.X)
 
 	# Copy over any additional data from mfinal_adata to cxg_adata
-	reserved_uns = ['schema_version', 'title', 'default_embedding', 'X_approximate_distribution']
+	reserved_uns = ['schema_version', 'title', 'default_embedding', 'X_approximate_distribution','schema_reference','citation']
 	for i in mfinal_adata.uns.keys():
 		if i == 'batch_condition':
 			if not isinstance(mfinal_adata.uns['batch_condition'], list) and not isinstance(mfinal_adata.uns['batch_condition'], np.ndarray) :
@@ -1503,7 +1503,8 @@ def main(mfinal_id):
 					cxg_adata.uns['batch_condition'] = mfinal_adata.uns['batch_condition']
 		elif i not in reserved_uns:
 			cxg_adata.uns[i] = mfinal_adata.uns[i]
-
+		else:
+			warning_list.append("WARNING: The key '{}' has been dropped from uns dict due to being reserved \n".format())
 
 	if mfinal_adata.obsp:
 		cxg_adata.obsp = mfinal_adata.obsp

--- a/scripts/flattener.py
+++ b/scripts/flattener.py
@@ -1483,6 +1483,10 @@ def main(mfinal_id):
 		map_antibody()
 		add_zero()
 
+	# Check that cxg_adata_raw.X is correct datatype
+	if not isinstance(cxg_adata_raw.X, np.float32):
+		cxg_adata_raw.X = cxg_adata_raw.X.astype(np.float32)
+
 	if not sparse.issparse(cxg_adata_raw.X):
 		cxg_adata_raw = ad.AnnData(X = sparse.csr_matrix(cxg_adata_raw.X), obs = cxg_adata_raw.obs, var = cxg_adata_raw.var)
 	elif cxg_adata.X.getformat()=='csc':

--- a/scripts/flattener.py
+++ b/scripts/flattener.py
@@ -1000,9 +1000,10 @@ def clean_obs():
 	make_numeric = ['suspension_percent_cell_viability','donor_BMI_at_collection']
 	for field in make_numeric:
 		if field in cxg_obs.columns:
-			if True in cxg_obs[field].str.contains('[<>-]|'+unreported_value, regex=True).to_list():
+			if True in cxg_obs[field].str.contains('[<>-]|'+unreported_value+'|'+'pooled', regex=True).to_list():
 				if True not in cxg_obs[field].str.contains('[<>-]', regex=True).to_list():
 					cxg_obs[field].replace({'unknown':np.nan}, inplace=True) 
+					cxg_obs[field][np.where(cxg_obs[field].str.contains('pooled') == True)[0].tolist()] = np.nan
 					cxg_obs[field]  = cxg_obs[field].astype('float')
 			else: 
 				cxg_obs[field]  = cxg_obs[field].astype('float')


### PR DESCRIPTION
Various updates in order to transition the flattener over to schema 4.0:

Adding tissue_type field to obs.

Making it so self_reported_ethnicity_ontology_term_id can be a list.

Adding a check for reserved uns names.

Adding a check that adata.X and adata.raw.X are the correct datatypes.

Adding feature_length to var.
