### PR TITLE
Tools 154 validate uns colors

### DIFF
--- a/scripts/flattener.py
+++ b/scripts/flattener.py
@@ -652,6 +652,8 @@ def quality_check(adata):
 		if len(adata.var.index.tolist()) > len(adata.raw.var.index.tolist()):
 			logging.error('ERROR: There are more genes in normalized genes than in raw matrix.')
 			sys.exit("ERROR: There are more genes in normalized genes than in raw matrix.")
+
+
 # Check validity of colors before adding to cxg_adata.uns
 def colors_check(adata, color_column, column_name):
 	# Check that obs column exists
@@ -668,7 +670,7 @@ def colors_check(adata, color_column, column_name):
 		error = 'the column does not contain strings.'
 		return False, error
 	# Verify that we have atleast as many colors as unique values in the obs column
-	if len(column_name) < len(adata.obs[column_name].unique()):
+	if len(color_column) < len(adata.obs[column_name].unique()):
 		error = 'the column has less colors than unique values in the corresponding obs. column.'
 		return False, error
 	# Verify that either all colors are hex OR all colors are CSS4 named colors strings
@@ -679,6 +681,8 @@ def colors_check(adata, color_column, column_name):
 		return False, error
 	else:
 		return True
+
+
 # Return value to be stored in disease field based on list of diseases from donor and sample
 def clean_list(lst, exp_disease):
 	lst = lst.split(',')

--- a/scripts/flattener.py
+++ b/scripts/flattener.py
@@ -18,6 +18,7 @@ import logging
 import gc
 from scipy import sparse
 from datetime import datetime
+import matplotlib.colors as mcolors
 
 # Reference files by which the flattener will filter var features
 ref_files = {

--- a/scripts/flattener.py
+++ b/scripts/flattener.py
@@ -657,11 +657,16 @@ def quality_check(adata):
 
 # Check validity of colors before adding to cxg_adata.uns
 def colors_check(adata, color_column, column_name):
-	# Check that obs column exists
 	column_name = column_name.replace('_colors','')
+	# Check that obs column exists
 	if column_name not in adata.obs.columns:
 		error = 'the corresponding column is not present in obs.'
 		return False, error
+	# Check that the corresponding column is the right datatype
+	if column_name in adata.obs.columns:
+		if adata.obs[column_name].dtype.name != 'category':
+			error = 'the corresponding column in obs. is the wrong datatype ({})'.format(adata.obs[column_name].dtype.name)
+			return False, error
 	# Verify color_column is a numpy array
 	if color_column is None or not isinstance(color_column, np.ndarray):
 		error = 'the column is not a numpy array.'

--- a/scripts/flattener.py
+++ b/scripts/flattener.py
@@ -1622,7 +1622,7 @@ def main(mfinal_id):
 			if colors_result[0]:
 				cxg_adata.uns[i] = mfinal_adata.uns[i]
 			else:
-				warning_list.append("WARNING: The colors column '{}' has been dropped from uns dict due to being invalid because '{}' \n".format(i,colors_result[1]))
+				warning_list.append("WARNING: '{}' has been dropped from uns dict due to being invalid because '{}' \n".format(i,colors_result[1]))
 		elif i not in reserved_uns:
 			cxg_adata.uns[i] = mfinal_adata.uns[i]
 		else:

--- a/scripts/flattener.py
+++ b/scripts/flattener.py
@@ -1031,7 +1031,7 @@ def clean_obs():
 	for field in change_unreported:
 		if field in cxg_obs.columns.to_list():
 			cxg_obs[field].replace({unreported_value: 'na'}, inplace=True)
-	valid_tissue_types = ['tissue', 'organoid', 'cell culture']
+	valid_tissue_types = ['tissue', 'organoid', 'cellculture']
 	cxg_obs['tissue_type'] = cxg_obs['tissue_type'].str.lower()
 	for i in cxg_obs['tissue_type'].unique().tolist():
 		if i == 'cellculture':

--- a/scripts/flattener.py
+++ b/scripts/flattener.py
@@ -681,7 +681,8 @@ def colors_check(adata, color_column, column_name):
 		error = 'the colors are not all hex or CSS4 named color strings.'
 		return False, error
 	else:
-		return True
+		error = 'none'
+		return True, error
 
 
 # Return value to be stored in disease field based on list of diseases from donor and sample


### PR DESCRIPTION
Adding checks for if _colors columns in uns are invalid. If invalid an error logging is displayed in the command prompt window.

Checks are as follows:
1. Check that corresponding obs column exists

2. Check if ‘_colors’ is of None type / not a numpy array

3. Check if ‘_colors’ contains non-string values

4. Check if ‘_colors’ has less entries than unique values in the associated obs column

5. Check if ‘_colors’ is not all hex / is not all CSS4 named colors

Jenny found an issue with the error logging for tissue type, and the presence of a space in ‘cellculture’ in valid_tissue_types.
The space has been removed so that valid_tissue_types now contains 'cellculture' instead of 'cell culture'.

I also added a quick fix to the warning output for an uns key being dropped so it now says what key was dropped.
