### PR TITLE
Tools 161 update visium schema

### DIFF
--- a/scripts/flattener.py
+++ b/scripts/flattener.py
@@ -690,7 +690,7 @@ def process_spatial():
 	global mfinal_obj
 
 	if cxg_obs['assay_ontology_term_id'].unique()[0] in ['EFO:0010961','EFO:0030062']:
-		if len(cxg_obs['library_uuid'].unique())==1:
+		if len(mfinal_obj.get('libraries'))==1:
 			if cxg_obs['assay_ontology_term_id'].unique()[0] == 'EFO:0010961':
 				cxg_uns['spatial'] = cxg_adata_raw.uns['spatial']
 				cxg_uns['spatial']['is_single'] = True
@@ -907,7 +907,6 @@ def main(mfinal_id):
 					download_file(mxr.get('s3_uri'), fm.MTX_DIR, mxr.get('accession'))
 
 			mxr_name = '{}.h5'.format(mxr_acc) if mxr['s3_uri'].endswith('h5') else '{}.h5ad'.format(mxr_acc)
-			print(mxr_name)
 			if mfinal_obj.get('spatial_s3_uri', None) and mfinal_obj['assays'] == ['spatial transcriptomics']:
 				# Checking for presence of spatial directory and redownloading if present
 				if os.path.exists(fm.MTX_DIR + '/spatial'):
@@ -1184,7 +1183,7 @@ def main(mfinal_id):
 	if mfinal_obj['assays'] == ['spatial transcriptomics']:
 		process_spatial()
 	# Check to see if need to add background spots
-	if len(cxg_obs['library_uuid'].unique()==1) and mfinal_obj.get('spatial_s3_uri', None):
+	if len(mfinal_obj.get('libraries'))==1 and mfinal_obj.get('spatial_s3_uri', None):
 		add_background_spots()
 		# Should delete this after validator 5.1 update
 		cxg_obsm['X_spatial'] = cxg_obsm['spatial']


### PR DESCRIPTION
This PR includes both https://lattice.atlassian.net/browse/TOOLS-161 and https://lattice.atlassian.net/browse/TOOLS-188 for both Visium and Slide-seqV2 assay. 

Here are some assumptions/behaviors:
- Spatial datasets will only be of a single assay ontology
- Only visium will have spatial_s3_uri
- Will use length of unique values in library_uuid to determine if dataset is merged spatial
- Will fill in with Nan for any author obs columns if there were background spots added.
- If Slide-seq single array dataset does not have X_spatial, will error and exit.

Tested:
- LATDF645CDP: Visium with fullres
- LATDF866GTS: Merged Visium
- LATDF372LSO: Single Slide-seqV2

Wanted to get a functioning branch merged into main today, hopefully, so that Jim can use that to work on some flattener updates. The flattener should really use objects to manage the variables rather that global variables. This week we can fully test additional Visium and Slide-seqV2 datasets to make sure everything is working as expected.
