### PR TITLE
matrix chunking for evaluate_dup_counts

### DIFF
--- a/cellxgene_resources/cellxgene_mods.py
+++ b/cellxgene_resources/cellxgene_mods.py
@@ -116,6 +116,7 @@ def get_adata_size(adata: ad.AnnData, show_stratified=True) -> int:
             "assay_ontology_term_id" in adata.obs.columns and
             VISIUM_ASSAY_TERM_ID in adata.obs["assay_ontology_term_id"].unique() and
             "spatial" in adata.uns.keys() and
+            "is_single" in adata.uns["spatial"] and
             adata.uns["spatial"]["is_single"] == True
         )
 

--- a/cellxgene_resources/cellxgene_mods.py
+++ b/cellxgene_resources/cellxgene_mods.py
@@ -9,7 +9,6 @@ import squidpy as sq
 import subprocess
 import sys
 from scipy import sparse
-from typing import Optional, Union
 
 
 portal_uns_fields = [
@@ -42,6 +41,8 @@ portal_obs_fields = [
 non_ontology_fields = ['donor_id','suspension_type','tissue_type','is_primary_data']
 curator_obs_fields = [e + '_ontology_term_id' for e in portal_obs_fields] + non_ontology_fields
 full_obs_standards = portal_obs_fields + curator_obs_fields
+
+VISIUM_ASSAY_TERM_ID = "EFO:0010961"
 
 
 class CxG_API:
@@ -94,6 +95,67 @@ def revise_cxg(adata):
 
 
     return adata
+
+
+def get_adata_size(adata: ad.AnnData, show_stratified=True) -> int:
+    """
+    Adapted from the adata.__sizeof__() method. This version will also return sizes of
+    adata.raw and the visium image arrays(per CXG schema) if they exist. Returns int of 
+    size and can print out itemized display
+    
+    :param: show_stratified: print out attribute sizes if set to True
+    """
+    def get_size(X) -> int:
+        if isinstance(X, (sparse.csr_matrix, sparse.csc_matrix, sparse.coo_matrix)):
+            return X.data.nbytes + X.indptr.nbytes + X.indices.nbytes
+        else:
+            return X.__sizeof__()
+
+    def is_visium_single(adata: ad.AnnData) -> bool:
+        return (
+            "assay_ontology_term_id" in adata.obs.columns and
+            VISIUM_ASSAY_TERM_ID in adata.obs["assay_ontology_term_id"].unique() and
+            "spatial" in adata.uns.keys() and
+            adata.uns["spatial"]["is_single"] == True
+        )
+
+    size = 0
+    attrs = list(["_X", "_obs", "_var"])
+    attrs_raw = list(["X", "var"])
+    attrs_multi = list(["_uns", "_obsm", "_varm", "varp", "_obsp", "_layers"])
+    if adata.raw:
+        adata_raw = adata.raw
+        attrs.extend(attrs_raw)
+        
+    for attr in attrs + attrs_multi:
+        if attr in attrs_multi:
+            keys = getattr(adata, attr).keys()
+            s = sum([get_size(getattr(adata, attr)[k]) for k in keys])
+        elif attr in attrs_raw:
+            s = get_size(getattr(adata_raw, attr))
+        else:
+            s = get_size(getattr(adata, attr))
+
+        if s > 0 and show_stratified:
+            if "_" not in attr:
+                str_attr = ".raw." + attr + " " * (13 - len(attr))
+            else:
+                str_attr = attr.replace("_", ".") + " " * (18 - len(attr))
+            print(f"Size of {str_attr}: {'%3.2f' % (s / (1024 ** 2))} MB")
+
+        size += s
+
+    if is_visium_single(adata):
+        library_id = [k for k in adata.uns["spatial"].keys() if "is_single" not in k][0]
+        print("Visium image arrays:") if show_stratified else None
+        for image_name, image_array in adata.uns["spatial"][library_id]["images"].items():
+            s = get_size(image_array)
+            if show_stratified:
+                str_name = image_name + " " * (18 - len(image_name))
+                print(f"Size of {str_name}: {'%3.2f' % (s / (1024 ** 2))} MB")
+            size += s
+            
+    return size
 
 
 def determine_sparsity(x):

--- a/cellxgene_resources/cellxgene_mods.py
+++ b/cellxgene_resources/cellxgene_mods.py
@@ -196,11 +196,11 @@ def evaluate_data(adata):
         report(f'raw min = {raw_min}')
         report(f'raw max = {raw_max}')
         min_maxs['raw'] = f'{raw_min}-{raw_max}'
-        non_integer = np.any(~np.equal(np.mod(adata.raw.X.data, 1), 0))
+        all_integers = np.all(np.round(adata.raw.X.data) == adata.raw.X.data)
     else:
-        non_integer = np.any(~np.equal(np.mod(adata.X.data, 1), 0))
+        all_integers = np.all(np.round(adata.X.data) == adata.X.data)
 
-    if non_integer == False:
+    if all_integers:
         report('raw is all integers', 'GOOD')
     else:
         report('raw contains non-integer values', 'ERROR')

--- a/cellxgene_resources/cellxgene_mods.py
+++ b/cellxgene_resources/cellxgene_mods.py
@@ -342,6 +342,7 @@ def evaluate_dup_counts(adata):
     if isinstance(matrix, np.ndarray):
         print("Matrix not in sparse format, please convert before hashing")
         return
+
     data_array = matrix.data
     index_array = matrix.indices
     indptr_array = matrix.indptr

--- a/cellxgene_resources/curation_qa.ipynb
+++ b/cellxgene_resources/curation_qa.ipynb
@@ -62,6 +62,15 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "get_adata_size(adata)"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -682,7 +691,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.18"
+   "version": "3.1.-1"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Using `_chunk_matrix()` function from the validator in the scc repo to prevent very high memory usage with the `evaluate_dup_counts()` function.

Little to no memory increase, speed seems decent but there is the possibility for multiprocessing optimization. I've tested with sparse matrices, should check and confirm dense matrices also work.

