### PR TITLE
get_adata_size cleanup

### DIFF
--- a/cellxgene_resources/cellxgene_mods.py
+++ b/cellxgene_resources/cellxgene_mods.py
@@ -114,7 +114,7 @@ def get_adata_size(adata: ad.AnnData, show_stratified=True) -> int:
     def has_visium_uns_images(adata: ad.AnnData) -> bool:
         return (
             "spatial" in adata.uns and
-            [k for k in adata.uns if "is_single" not in k]
+            [k for k in adata.uns["spatial"] if "is_single" not in k]
         )
 
     size = 0

--- a/cellxgene_resources/curation_qa.ipynb
+++ b/cellxgene_resources/curation_qa.ipynb
@@ -62,15 +62,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "get_adata_size(adata)"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -691,7 +682,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.1.-1"
+   "version": "3.11.8"
   }
  },
  "nbformat": 4,

--- a/cellxgene_resources/curation_sample_code.ipynb
+++ b/cellxgene_resources/curation_sample_code.ipynb
@@ -15,8 +15,8 @@
     "## Table of Contents\n",
     "* **CELLxGENE Revision**\n",
     " * [Remove CELLxGENE portal fields](#revision)\n",
-    "* **Adata**\n",
-    " * [Get size of adata object and attributes](#adata_size)\n",
+    "* **AnnData**\n",
+    " * [Get size of AnnData object and attributes](#adata_size)\n",
     "* **Matrix**\n",
     " * [Convert matrix to sparse](#sparsity)\n",
     " * [Convert raw matrix to sparse](#sparsity-raw)\n",
@@ -78,14 +78,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Adata"
+    "# AnnData"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "**Get size of adata and attributes, including raw and visium image arrays if they exist** <a class=\"anchor\" id=\"adata_size\"></a>"
+    "**Get size of AnnData object and its attributes, including raw and visium image arrays if they exist** <a class=\"anchor\" id=\"adata_size\"></a>"
    ]
   },
   {

--- a/cellxgene_resources/curation_sample_code.ipynb
+++ b/cellxgene_resources/curation_sample_code.ipynb
@@ -15,6 +15,8 @@
     "## Table of Contents\n",
     "* **CELLxGENE Revision**\n",
     " * [Remove CELLxGENE portal fields](#revision)\n",
+    "* **Adata**\n",
+    " * [Get size of adata object and attributes](#adata_size)\n",
     "* **Matrix**\n",
     " * [Convert matrix to sparse](#sparsity)\n",
     " * [Convert raw matrix to sparse](#sparsity-raw)\n",
@@ -70,6 +72,32 @@
     "\n",
     "\n",
     "adata = revise_cxg(adata)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Adata"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Get size of adata and attributes, including raw and visium image arrays if they exist** <a class=\"anchor\" id=\"adata_size\"></a>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from cellxgene_mods import get_adata_size\n",
+    "\n",
+    "\n",
+    "get_adata_size(adata)"
    ]
   },
   {
@@ -929,7 +957,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.18"
+   "version": "3.1.undefined"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Fixed bug in `get_adata_size()` for visium image array check. slide seq datasets would error due to missing uns['spatial'] in second line of check.

Also moving this function to sample_curation_notebook for use when needed