### PR TITLE
AnnData/h5 size loaded into memory

### DIFF
--- a/cellxgene_resources/cellxgene_mods.py
+++ b/cellxgene_resources/cellxgene_mods.py
@@ -165,7 +165,7 @@ class Sizes:
     attr_size_dict = {}
 
 
-def calculate_adata_memory(adata_path: str, print_datasets: bool = True, sizes: Sizes | None = None) -> Sizes:
+def calculate_adata_memory(adata_path: str, print_datasets: bool = False, sizes: Sizes | None = None) -> Sizes:
     """
     Calculate size of AnnData object when fully loaded in memory. Reads header/metadata information
     in h5/h5ad file and returns size of object loaded into RAM and calculated size on disk. 
@@ -173,7 +173,7 @@ def calculate_adata_memory(adata_path: str, print_datasets: bool = True, sizes: 
     on specific h5 datasets.
     
     :param: adata_path: str path to h5/h5ad file. Will only load header/metadata info, not full file
-    :param: print_datasets: Default True, set to False to only get final RAM and disk size
+    :param: print_datasets: Default False, set to True to get print out of individual datasets
 
     :returns: Sizes object
     """


### PR DESCRIPTION
`calculate_adata_memory()` takes str path of local h5/h5ad file and returns size in bytes on disk and when file is fully loaded into memory. Returns a `Sizes` dataclass that has size attributes plus a dictionary, `attr_size_dict`, that contains h5 dataset name: nbytes if one wishes to have these values to further calculate aggregate sizes. Default print out displays only disk and RAM sizes, set `print_datasets=True` to get print out for every dataset within the h5/h5ad file.

Tested on a variety of h5 and h5ad files, both compressed and uncompressed.  

For now I have kept `get_adata_size()`, though this new function should probably replace this function; `get_adata_size()` needs to fully load the file into memory in order to calculate sizes where `calculate_adata_memory()` only reads h5 header/metadata information.