### PR TITLE
Tools 199 add tier1 required id name fields to all datasets

### DIFF
--- a/scripts/flattener.py
+++ b/scripts/flattener.py
@@ -491,16 +491,22 @@ def clean_obs(glob):
 		if author_col in glob.mfinal_adata.obs.columns.to_list():
 			if author_col == 'sample_id':
 				# Check that sample_id and sample_uuid have same key-value pairings and length of keys
-				if glob.mfinal_adata.obs[[author_col]].value_counts().values == glob.cxg_obs['sample_uuid'].value_counts().values:
-					glob.cxg_obs.drop(columns='sample_uuid', inplace=True)
-					glob.cxg_obs = pd.merge(glob.cxg_obs, glob.mfinal_adata.obs[[author_col]], left_index=True, right_index=True, how='left')
+				if len(glob.mfinal_adata.obs[[author_col]].value_counts().values) == len(glob.cxg_obs['sample_uuid'].value_counts().values):
+					if glob.mfinal_adata.obs[[author_col]].value_counts().values == glob.cxg_obs['sample_uuid'].value_counts().values:
+						glob.cxg_obs.drop(columns='sample_uuid', inplace=True)
+						glob.cxg_obs = pd.merge(glob.cxg_obs, glob.mfinal_adata.obs[[author_col]], left_index=True, right_index=True, how='left')
+					else:
+						glob.cxg_obs.rename(columns={'sample_uuid':'sample_id'},inplace=True)
 				else:
 					glob.cxg_obs.rename(columns={'sample_uuid':'sample_id'},inplace=True)
 			if author_col == 'library_id':
 				# Check that library_id and library_uuid have same key-value pairings and length of keys
-				if glob.mfinal_adata.obs[[author_col]].value_counts().values == glob.cxg_obs['library_uuid'].value_counts().values:
-					glob.cxg_obs.drop(columns='library_uuid', inplace=True)
-					glob.cxg_obs = pd.merge(glob.cxg_obs, glob.mfinal_adata.obs[[author_col]], left_index=True, right_index=True, how='left')
+				if len(glob.mfinal_adata.obs[[author_col]].value_counts().values) == len(glob.cxg_obs['library_uuid'].value_counts().values):
+					if glob.mfinal_adata.obs[[author_col]].value_counts().values == glob.cxg_obs['library_uuid'].value_counts().values:
+						glob.cxg_obs.drop(columns='library_uuid', inplace=True)
+						glob.cxg_obs = pd.merge(glob.cxg_obs, glob.mfinal_adata.obs[[author_col]], left_index=True, right_index=True, how='left')
+					else:
+						glob.cxg_obs.rename(columns={'library_uuid':'library_id'},inplace=True)
 				else:
 					glob.cxg_obs.rename(columns={'library_uuid':'library_id'},inplace=True)
 			else:		

--- a/scripts/flattener.py
+++ b/scripts/flattener.py
@@ -486,20 +486,17 @@ def map_antibody(glob):
 def clean_obs(glob):
 	# For columns in mfinal_obj that contain continuous cell metrics, they are transferred to cxg_obs as float datatype
 	# WILL NEED TO REVISIT IF FINAL MATRIX CONTAINS MULTIPLE LAYERS THAT WE ARE WRANGLING
-	samp_id_present = False
-	lib_id_present = False
-	for author_col in glob.mfinal_obj.get('author_columns', []):
+	mfinal_author_cols = glob.mfinal_obj.get('author_columns', [])
+	for author_col in mfinal_author_cols:
 		if author_col in glob.mfinal_adata.obs.columns.to_list():
 			if author_col == 'sample_id':
 				# Check that sample_id and sample_uuid have same key-value pairings and length of keys
 				if glob.mfinal_adata.obs[[author_col]].value_counts().values == glob.cxg_obs['sample_uuid'].value_counts().values:
-					samp_id_present = True
 					glob.cxg_obs.drop(columns='sample_uuid', inplace=True)
 					glob.cxg_obs = pd.merge(glob.cxg_obs, glob.mfinal_adata.obs[[author_col]], left_index=True, right_index=True, how='left')
 			if author_col == 'library_id':
 				# Check that library_id and library_uuid have same key-value pairings and length of keys
 				if glob.mfinal_adata.obs[[author_col]].value_counts().values == glob.cxg_obs['library_uuid'].value_counts().values:
-					lib_id_present = True
 					glob.cxg_obs.drop(columns='library_uuid', inplace=True)
 					glob.cxg_obs = pd.merge(glob.cxg_obs, glob.mfinal_adata.obs[[author_col]], left_index=True, right_index=True, how='left')
 			else:		
@@ -507,9 +504,9 @@ def clean_obs(glob):
 		else:
 			warning_list.append("WARNING: author_column not in final matrix: {}".format(author_col))
 	# Still rename uuid terms even if author column not present
-	if samp_id_present == False:
+	if 'sample_id' not in mfinal_author_cols:
 		glob.cxg_obs.rename(columns={'sample_uuid':'sample_id'},inplace=True)
-	if lib_id_present == False:
+	if 'library_id' not in mfinal_author_cols:
 		glob.cxg_obs.rename(columns={'library_uuid':'library_id'},inplace=True)
 	# if obs category suspension_type does not exist in dataset, create column and fill values with na (for spatial assay)
 	if 'suspension_type' not in glob.cxg_obs.columns:

--- a/scripts/flattener.py
+++ b/scripts/flattener.py
@@ -494,11 +494,15 @@ def clean_obs(glob):
 				if glob.mfinal_adata.obs[[author_col]].value_counts().values == glob.cxg_obs['sample_uuid'].value_counts().values:
 					glob.cxg_obs.drop(columns='sample_uuid', inplace=True)
 					glob.cxg_obs = pd.merge(glob.cxg_obs, glob.mfinal_adata.obs[[author_col]], left_index=True, right_index=True, how='left')
+				else:
+					glob.cxg_obs.rename(columns={'sample_uuid':'sample_id'},inplace=True)
 			if author_col == 'library_id':
 				# Check that library_id and library_uuid have same key-value pairings and length of keys
 				if glob.mfinal_adata.obs[[author_col]].value_counts().values == glob.cxg_obs['library_uuid'].value_counts().values:
 					glob.cxg_obs.drop(columns='library_uuid', inplace=True)
 					glob.cxg_obs = pd.merge(glob.cxg_obs, glob.mfinal_adata.obs[[author_col]], left_index=True, right_index=True, how='left')
+				else:
+					glob.cxg_obs.rename(columns={'library_uuid':'library_id'},inplace=True)
 			else:		
 				glob.cxg_obs = pd.merge(glob.cxg_obs, glob.mfinal_adata.obs[[author_col]], left_index=True, right_index=True, how='left')
 		else:

--- a/scripts/flattener.py
+++ b/scripts/flattener.py
@@ -489,27 +489,18 @@ def clean_obs(glob):
 	mfinal_author_cols = glob.mfinal_obj.get('author_columns', [])
 	for author_col in mfinal_author_cols:
 		if author_col in glob.mfinal_adata.obs.columns.to_list():
-			if author_col == 'sample_id':
-				# Check that sample_id and sample_uuid have same key-value pairings and length of keys
-				if len(glob.mfinal_adata.obs[[author_col]].value_counts().values) == len(glob.cxg_obs['sample_uuid'].value_counts().values):
-					if glob.mfinal_adata.obs[[author_col]].value_counts().values == glob.cxg_obs['sample_uuid'].value_counts().values:
-						glob.cxg_obs.drop(columns='sample_uuid', inplace=True)
+			if author_col == 'sample_id' or author_col == 'library_id':
+				uuid_col = author_col.replace('id', 'uuid')
+				# Check that _id and _uuid have same key-value pairings and length of keys
+				if len(glob.mfinal_adata.obs[[author_col]].value_counts().values) == len(glob.cxg_obs[uuid_col].value_counts().values):
+					if (glob.mfinal_adata.obs[[author_col]].value_counts().values == glob.cxg_obs[uuid_col].value_counts().values).all():
+						glob.cxg_obs.drop(columns=uuid_col, inplace=True)
 						glob.cxg_obs = pd.merge(glob.cxg_obs, glob.mfinal_adata.obs[[author_col]], left_index=True, right_index=True, how='left')
 					else:
-						glob.cxg_obs.rename(columns={'sample_uuid':'sample_id'},inplace=True)
+						glob.cxg_obs.rename(columns={uuid_col:author_col}, inplace=True)
 				else:
-					glob.cxg_obs.rename(columns={'sample_uuid':'sample_id'},inplace=True)
-			if author_col == 'library_id':
-				# Check that library_id and library_uuid have same key-value pairings and length of keys
-				if len(glob.mfinal_adata.obs[[author_col]].value_counts().values) == len(glob.cxg_obs['library_uuid'].value_counts().values):
-					if glob.mfinal_adata.obs[[author_col]].value_counts().values == glob.cxg_obs['library_uuid'].value_counts().values:
-						glob.cxg_obs.drop(columns='library_uuid', inplace=True)
-						glob.cxg_obs = pd.merge(glob.cxg_obs, glob.mfinal_adata.obs[[author_col]], left_index=True, right_index=True, how='left')
-					else:
-						glob.cxg_obs.rename(columns={'library_uuid':'library_id'},inplace=True)
-				else:
-					glob.cxg_obs.rename(columns={'library_uuid':'library_id'},inplace=True)
-			else:		
+					glob.cxg_obs.rename(columns={uuid_col:author_col}, inplace=True)
+			else:	
 				glob.cxg_obs = pd.merge(glob.cxg_obs, glob.mfinal_adata.obs[[author_col]], left_index=True, right_index=True, how='left')
 		else:
 			warning_list.append("WARNING: author_column not in final matrix: {}".format(author_col))

--- a/scripts/flattener_mods/constants.py
+++ b/scripts/flattener_mods/constants.py
@@ -73,7 +73,8 @@ CELL_METADATA = {
 		'protocol.assay_ontology.term_id',
 		'starting_quantity',
 		'starting_quantity_units',
-		'@id'
+		'@id',
+		'lab.institute_name'
 	],
 	'raw_matrix': [
 		'assembly',
@@ -127,6 +128,7 @@ PROP_MAP = {
 	'sample_genetic_modifications': 'genetic_modifications',
 	'sample_menstrual_phase_at_collection': 'menstrual_phase_at_collection',
 	'library_protocol_assay_ontology_term_id': 'assay_ontology_term_id',
+	'library_lab_institute_name': 'institute',
 	'donor_sex': 'sex',
 	'sample_@type': 'tissue_type',
 	'donor_donor_id': 'donor_id',


### PR DESCRIPTION
Added code to clean_obs in flattener.py to check for presence of 'library_id' and 'sample_id' in author_columns of processed_matrix_file. If present, a check will occur of the count values between these columns and the _uuid columns already present in the cxg_obs dataframe. If the counts match up, we can be sure that there is a 1:1 relationship between the two columns (even if the values are different), so the _uuid columns are replaced with the author_column information. If the counts check fails the original _uuid columns are kept and renamed.If the author columns are not present, the _uuid columns are kept and renamed.

Institute was added by modifying the CELL_METADATA dict in constants.py to include lab.institute as metadata to collect for library. The resulting column is named 'library_lab_institute_name', so a mapping of this to 'insititute' was added in the PROP_MAP dict.