### PR TITLE
Tools 201 genome annotate and fix for software field

### DIFF
--- a/scripts/flattener.py
+++ b/scripts/flattener.py
@@ -539,8 +539,8 @@ def clean_obs(glob):
 		glob.cxg_obs[[i for i in glob.cxg_obs.columns.tolist() if i.startswith('family_history_')]].fillna(value='unknown')
 	
 	# map gencode to ensembl version for HCA tier 1
-	if 'mapped_reference_annotation' in glob.cxg_obs.columns:
-		glob.cxg_obs['gene_annotation_version'] = glob.cxg_obs['mapped_reference_annotation'].map(fm.GENCODE_MAP)
+	if 'gene_annotation_version' in glob.cxg_obs.columns:
+		glob.cxg_obs['gene_annotation_version'] = glob.cxg_obs['gene_annotation_version'].map(fm.GENCODE_MAP)
 
 
 # Drop any intermediate or optional fields that are all empty
@@ -551,7 +551,7 @@ def drop_cols(celltype_col, glob):
 			'donor_living_at_sample_collection', 'donor_menopausal_status', 'donor_smoking_status', 'sample_derivation_process', 'suspension_dissociation_reagent',\
 			'suspension_dissociation_time', 'suspension_depleted_cell_types', 'suspension_derivation_process', 'suspension_percent_cell_viability',\
 			'library_starting_quantity', 'library_starting_quantity_units', 'tissue_handling_interval', 'suspension_dissociation_time_units', 'alignment_software',\
-			'mapped_reference_annotation', 'mapped_reference_assembly', 'sequencing_platform', 'sample_source', 'donor_cause_of_death', 'growth_medium', 'genetic_modifications',
+			'gene_annotation_version', 'reference_genome', 'sequencing_platform', 'sample_source', 'donor_cause_of_death', 'growth_medium', 'genetic_modifications',
 			'menstrual_phase_at_collection']
 	
 	if 'sequencing_platform' in glob.cxg_obs.columns:
@@ -823,7 +823,7 @@ def main(mfinal_id):
 				sys.exit('ERROR: Raw matrix file of unknown file extension: {}'.format(mxr['s3_uri']))
 
 			if summary_assay == 'RNA':
-				row_to_add['mapped_reference_annotation'] = mxr['genome_annotation']
+				row_to_add['gene_annotation_version'] = mxr['genome_annotation']
 				adata_raw = adata_raw[:, adata_raw.var['feature_types']=='Gene Expression']
 			else:
 				adata_raw = adata_raw[:, adata_raw.var['feature_types']=='Antibody Capture']
@@ -892,9 +892,9 @@ def main(mfinal_id):
 		df = pd.concat([df, row_to_add])
 		redundant = list(set(redundant))
 		
-	# Removing mapped_reference_annotation if genome_annotations from ProcMatrixFile is empty
+	# Removing gene_annotation_version if genome_annotations from ProcMatrixFile is empty
 	if not glob.mfinal_obj.get('genome_annotations', None):
-		del df['mapped_reference_annotation']
+		del df['gene_annotation_version']
 
 	if mapping_error:
 		logging.error('ERROR: There are {} mapping errors in cell_label_mappings:'.format(len(error_info.keys())))

--- a/scripts/flattener.py
+++ b/scripts/flattener.py
@@ -537,6 +537,10 @@ def clean_obs(glob):
 
 	glob.cxg_obs[[i for i in glob.cxg_obs.columns.tolist() if i.startswith('family_history_')]] = \
 		glob.cxg_obs[[i for i in glob.cxg_obs.columns.tolist() if i.startswith('family_history_')]].fillna(value='unknown')
+	
+	# map gencode to ensembl version for HCA tier 1
+	if 'mapped_reference_annotation' in glob.cxg_obs.columns:
+		glob.cxg_obs['gene_annotation_version'] = glob.cxg_obs['mapped_reference_annotation'].map(fm.GENCODE_MAP)
 
 
 # Drop any intermediate or optional fields that are all empty
@@ -547,7 +551,7 @@ def drop_cols(celltype_col, glob):
 			'donor_living_at_sample_collection', 'donor_menopausal_status', 'donor_smoking_status', 'sample_derivation_process', 'suspension_dissociation_reagent',\
 			'suspension_dissociation_time', 'suspension_depleted_cell_types', 'suspension_derivation_process', 'suspension_percent_cell_viability',\
 			'library_starting_quantity', 'library_starting_quantity_units', 'tissue_handling_interval', 'suspension_dissociation_time_units', 'alignment_software',\
-			'mapped_reference_annotation', 'mapped_reference_assembly', 'sequencing_platform', 'sample_source', 'donor_cause_of_death', 'growth_medium', 'genetic_modifications',
+			'mapped_reference_annotation', 'sequencing_platform', 'sample_source', 'donor_cause_of_death', 'growth_medium', 'genetic_modifications',
 			'menstrual_phase_at_collection']
 	
 	if 'sequencing_platform' in glob.cxg_obs.columns:

--- a/scripts/flattener.py
+++ b/scripts/flattener.py
@@ -551,7 +551,7 @@ def drop_cols(celltype_col, glob):
 			'donor_living_at_sample_collection', 'donor_menopausal_status', 'donor_smoking_status', 'sample_derivation_process', 'suspension_dissociation_reagent',\
 			'suspension_dissociation_time', 'suspension_depleted_cell_types', 'suspension_derivation_process', 'suspension_percent_cell_viability',\
 			'library_starting_quantity', 'library_starting_quantity_units', 'tissue_handling_interval', 'suspension_dissociation_time_units', 'alignment_software',\
-			'mapped_reference_annotation', 'sequencing_platform', 'sample_source', 'donor_cause_of_death', 'growth_medium', 'genetic_modifications',
+			'mapped_reference_annotation', 'mapped_reference_assembly', 'sequencing_platform', 'sample_source', 'donor_cause_of_death', 'growth_medium', 'genetic_modifications',
 			'menstrual_phase_at_collection']
 	
 	if 'sequencing_platform' in glob.cxg_obs.columns:

--- a/scripts/flattener_mods/__init__.py
+++ b/scripts/flattener_mods/__init__.py
@@ -1,3 +1,3 @@
 from flattener_mods.gather import gather_rawmatrices, gather_objects, gather_metdata, gather_pooled_metadata, get_value
-from flattener_mods.constants import UNREPORTED_VALUE, SCHEMA_VERSION, MTX_DIR, REF_FILES, CELL_METADATA, DATASET_METADATA, ANNOT_FIELDS, ANTIBODY_METADATA, PROP_MAP
+from flattener_mods.constants import UNREPORTED_VALUE, SCHEMA_VERSION, MTX_DIR, REF_FILES, CELL_METADATA, DATASET_METADATA, ANNOT_FIELDS, ANTIBODY_METADATA, PROP_MAP, GENCODE_MAP
 from flattener_mods.uns_functions import colors_check, check_not_empty, copy_over_uns, process_spatial

--- a/scripts/flattener_mods/constants.py
+++ b/scripts/flattener_mods/constants.py
@@ -155,8 +155,8 @@ PROP_MAP = {
 	'antibody_host_organism': 'host_organism',
 	'target_organism_scientific_name': 'target_organism',
 	'raw_matrix_software': 'alignment_software',
-	'raw_matrix_genome_annotation': 'mapped_reference_annotation',
-	'raw_matrix_assembly': 'mapped_reference_assembly',
+	'raw_matrix_genome_annotation': 'gene_annotation_version',
+	'raw_matrix_assembly': 'reference_genome',
 	'seq_run_platform': 'sequencing_platform'
 }
 

--- a/scripts/flattener_mods/constants.py
+++ b/scripts/flattener_mods/constants.py
@@ -159,3 +159,32 @@ PROP_MAP = {
 	'raw_matrix_assembly': 'mapped_reference_assembly',
 	'seq_run_platform': 'sequencing_platform'
 }
+
+GENCODE_MAP = {
+	'GENCODE 44': 'v110',
+	'GENCODE 43': 'v109',
+	'GENCODE 42': 'v108',
+	'GENCODE 41': 'v107',
+	'GENCODE 40': 'v106',
+	'GENCODE 39': 'v105',
+	'GENCODE 38': 'v104',
+	'GENCODE 37': 'v103',
+	'GENCODE 36': 'v102',
+	'GENCODE 35': 'v101',
+	'GENCODE 34': 'v100',
+	'GENCODE 33': 'v99',
+	'GENCODE 32': 'v98',
+	'GENCODE 31': 'v97',
+	'GENCODE 30': 'v96',
+	'GENCODE 29': 'v94',
+	'GENCODE 28': 'v92',
+	'GENCODE 27': 'v90',
+	'GENCODE 26': 'v88',
+	'GENCODE 25': 'v85',
+	'GENCODE 24': 'v83',
+	'GENCODE 23': 'v81',
+	'GENCODE 22': 'v79',
+	'GENCODE 21': 'v77',
+	'GENCODE 20': 'v76',
+	'GENCODE 19': 'v74',
+}

--- a/scripts/flattener_mods/gather.py
+++ b/scripts/flattener_mods/gather.py
@@ -15,6 +15,7 @@ logger = logging.getLogger(__name__)
 def gather_rawmatrices(derived_from, connection):
 	'''
 	Utilize lattice parse_ids and get_report to get all the raw matrix objects at once
+    Will return only fields in field_lst
 
 	:param List[str] derived_from: Raw matrices up the experimental graph which the final matrix object is derived from
 	:param obj connection: Information for connecting to lattice database
@@ -37,7 +38,7 @@ def gather_rawmatrices(derived_from, connection):
 	
 	# If object type of the original derived_from ids is not raw matrix file, go another layer down
 	if obj_type != 'RawMatrixFile':
-		objs = lattice.get_report(obj_type,filter_list,['derived_from'],connection)
+		objs = lattice.get_report(obj_type,filter_lst,['derived_from'],connection)
 		for obj in objs:
 			new_derived_from.append(obj['derived_from'])
 		obj_type, filter_lst = lattice.parse_ids(new_derived_from)

--- a/scripts/flattener_mods/gather.py
+++ b/scripts/flattener_mods/gather.py
@@ -15,35 +15,27 @@ logger = logging.getLogger(__name__)
 def gather_rawmatrices(derived_from, connection):
 	'''
 	Utilize lattice parse_ids and get_report to get all the raw matrix objects at once
-    Will return only fields in field_lst
+	Will return only fields in field_lst
 
 	:param List[str] derived_from: Raw matrices up the experimental graph which the final matrix object is derived from
 	:param obj connection: Information for connecting to lattice database
 
 	:returns List[dict] my_raw_matrices: List of raw matrices which the final matrix object is derived from
 	'''
-	new_derived_from = []
 	field_lst = [
-        '@id',
-        'accession',
-        's3_uri',
-        'genome_annotation',
-        'assembly',
-        'libraries',
-        'derived_from',
-        'software',
-    ]
+		'@id',
+		'accession',
+		's3_uri',
+		'genome_annotation',
+		'assembly',
+		'libraries',
+		'derived_from',
+		'software',
+	]
 	
 	obj_type, filter_lst = lattice.parse_ids(derived_from)
 	
-	# If object type of the original derived_from ids is not raw matrix file, go another layer down
-	if obj_type != 'RawMatrixFile':
-		objs = lattice.get_report(obj_type,filter_lst,['derived_from'],connection)
-		for obj in objs:
-			new_derived_from.append(obj['derived_from'])
-		obj_type, filter_lst = lattice.parse_ids(new_derived_from)
-		
-	my_raw_matrices = lattice.get_report(obj_type,filter_lst,field_lst,connection)
+	my_raw_matrices = lattice.get_report(obj_type, filter_lst, field_lst, connection)
 
 	return my_raw_matrices
 

--- a/scripts/flattener_mods/gather.py
+++ b/scripts/flattener_mods/gather.py
@@ -30,6 +30,7 @@ def gather_rawmatrices(derived_from, connection):
         'assembly',
         'libraries',
         'derived_from',
+        'software',
     ]
 	
 	obj_type, filter_lst = lattice.parse_ids(derived_from)

--- a/scripts/flattener_mods/gather.py
+++ b/scripts/flattener_mods/gather.py
@@ -22,7 +22,15 @@ def gather_rawmatrices(derived_from, connection):
 	:returns List[dict] my_raw_matrices: List of raw matrices which the final matrix object is derived from
 	'''
 	new_derived_from = []
-	field_lst = ['@id','accession','s3_uri','genome_annotation','libraries','derived_from']
+	field_lst = [
+        '@id',
+        'accession',
+        's3_uri',
+        'genome_annotation',
+        'assembly',
+        'libraries',
+        'derived_from',
+    ]
 	
 	obj_type, filter_lst = lattice.parse_ids(derived_from)
 	


### PR DESCRIPTION
Renaming two fields:
- `mapped_reference_genome` to `reference_genome`
- `mapped_reference_annotation` to `gene_annotation_version`

`gene_annotation_version` remaps GENCODE annotation to Ensembl version. Used hardcoded map/dict in `flattener_mods/constants.py`; check in `clean_obs()` if `gene_annotation_version` column exists before mapping since not all ProcessedMatrixFiles contain annotation metadata.

Also addressing bug where `RawMatrixFile.assembly` and `RawMatrixFile.software` were filtered out in the `gather_rawmatrices()` function. Adding these fields to the local `field_lst` list now correctly gathers this metadata.

Tested using the following ProcessedMatrixFiles (various combinations of reference genomes with no annotations, one annotation, many annotations):
- `LATDF519CUZ`
- `LATDF808TGB`
- `LATDF190KNY`
- `LATDF805MJO`
- `LATDF366MLP`
- `LATDF372LSO`

Finally, typo on line 41 of `gather.py`: changed `filter_list` to `filter_lst` like in the rest of the function. This is within an if block if the object is not a RawMatrixFile; this may not have surfaced yet as a potential bug and I'm not sure if the above ProcessedMatrixFiles triggered this block. Hopefully someone else knows of a case or way to properly test this, if not, we can leave for now.