### PR TITLE
change np.bool to bool

### DIFF
--- a/scripts/flattener_mods/uns_functions.py
+++ b/scripts/flattener_mods/uns_functions.py
@@ -83,7 +83,7 @@ def check_not_empty(value):
 		value is not None
 		and not isinstance(value, numbers.Number)
 		and type(value) is not bool
-		and not (isinstance(value, (np.bool_, np.bool)))
+		and not (isinstance(value, (np.bool_, bool)))
 		and len(value) == 0
 	):
 		return False


### PR DESCRIPTION
While running through standard set of ProcessedMatrixFiles to test the flattener, encountered the following error:

> Traceback (most recent call last):
>   File "/mnt/lattice-tools/scripts/flattener.py", line 1173, in <module>
>     main(args.file)
>   File "/mnt/lattice-tools/scripts/flattener.py", line 1143, in main
>     warnings = fm.copy_over_uns(glob, reserved_uns)
>                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
>   File "/mnt/lattice-tools/scripts/flattener_mods/uns_functions.py", line 121, in copy_over_uns
>     if check_not_empty(v):
>        ^^^^^^^^^^^^^^^^^^
>   File "/mnt/lattice-tools/scripts/flattener_mods/uns_functions.py", line 86, in check_not_empty
>     and not (isinstance(value, (np.bool_, np.bool)))
>                                           ^^^^^^^
>   File "/mnt/anaconda3/envs/lattice/lib/python3.11/site-packages/numpy/__init__.py", line 324, in __getattr__
>     raise AttributeError(__former_attrs__[attr])
> AttributeError: module 'numpy' has no attribute 'bool'.
> `np.bool` was a deprecated alias for the builtin `bool`. To avoid this error in existing code, use `bool` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.bool_` here.
> The aliases was originally deprecated in NumPy 1.20; for more detail

Replacing `np.bool` with `bool`. We use numpy==1.26.4 for most python envs

Tested `LATDF742BQI` on prod and demo