### PR TITLE
Fix ArrayView error when adata.X is dense array

### DIFF
--- a/scripts/flattener.py
+++ b/scripts/flattener.py
@@ -282,7 +282,7 @@ def get_sex_ontology(donor_df):
 def add_zero(glob):
 	if glob.cxg_adata_raw.shape[1] > glob.cxg_adata.shape[1]:
 		genes_add = [x for x in glob.cxg_adata_raw.var.index.to_list() if x not in glob.cxg_adata.var.index.to_list()]
-		new_matrix = sparse.csr_matrix((glob.cxg_adata.X.data, glob.cxg_adata.X.indices, glob.cxg_adata.X.indptr), shape=glob.cxg_adata_raw.shape)
+		new_matrix = sparse.csr_matrix(glob.cxg_adata.X, shape=glob.cxg_adata_raw.shape)
 		all_genes = glob.cxg_adata.var.index.to_list()
 		all_genes.extend(genes_add)
 		new_var = pd.DataFrame(index=all_genes)


### PR DESCRIPTION
Further info at: https://lattice.atlassian.net/browse/TOOLS-214

While flattening LATDF773LWI:

```
LATDF333APT.h5 was found locally
LATDF496WLW.h5 was found locally
Traceback (most recent call last):
  File "/mnt/lattice-tools/scripts/flattener.py", line 1173, in <module>
    main(args.file)
  File "/mnt/lattice-tools/scripts/flattener.py", line 1128, in main
    add_zero(glob)
  File "/mnt/lattice-tools/scripts/flattener.py", line 285, in add_zero
    new_matrix = sparse.csr_matrix((glob.cxg_adata.X.data, glob.cxg_adata.X.indices, glob.cxg_adata.X.indptr), shape=glob.cxg_adata_raw.shape)
                                                           ^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'ArrayView' object has no attribute 'indices'
```
Figured out issue: LATDF773LWI.h5ad has a dense numpy array in X. This is a normalized matrix with only 1999 genes; its in-memory size is smaller than the equivalent csr matrix, so maybe that’s why the dense array was used. The current line of code needs adata.X to be in sparse format with the three numpy arrays present that represent the sparse data (data, indices, indptr).

sparse.csr_matrix() can take a [variety of inputs and return a sparse matrix](https://docs.scipy.org/doc/scipy/reference/generated/scipy.sparse.csr_matrix.html), so using just the argument Anndata_object.X covers cases where the X could be sparse or dense.

I can manually change the original h5ad to have X as a csr matrix and the file flattens with the original code. If I keep the original h5ad and modify to sparse.csr_matrix(adata.X), then the original file (both with a dense array or sparse array) also flattens. The hashes for all flattened files are equivalent.

Also tested 9 other files per Jira ticket; h5ad hashes before change and after change were the same.

On line 295, this code for individual layer conversion to sparse also assumes all layers are already in sparse format. Might be worthwhile to change this line to just accept the layer matrix and not the three sparse format arrays for each layer.

Line 1117 calls `check_matrix()` for each layer to keep and converts to csr format so layers will likely be in sparse format before `add_zero()` is called. For `LATDF293IUI` and `LATDF742BQI`, I manually changed the layers to dense and it looks like `check_matrix()` converts them to sparse before `add_zero()`.