### PR TITLE
update for calculate_adata_memory in sample code notebook

### DIFF
--- a/cellxgene_resources/cellxgene_mods.py
+++ b/cellxgene_resources/cellxgene_mods.py
@@ -97,67 +97,6 @@ def revise_cxg(adata):
     return adata
 
 
-def get_adata_size(adata: ad.AnnData, show_stratified=True) -> int:
-    """
-    Adapted from the adata.__sizeof__() method. This version will also return sizes of
-    adata.raw and the visium image arrays if they exist. Returns int of 
-    size and can print out itemized display
-    
-    :param: show_stratified: print out attribute sizes if set to True
-    """
-    def get_size(X) -> int:
-        if isinstance(X, (sparse.csr_matrix, sparse.csc_matrix, sparse.coo_matrix)):
-            return X.data.nbytes + X.indptr.nbytes + X.indices.nbytes
-        elif isinstance(X, np.ndarray):
-            return X.nbytes
-        else:
-            return X.__sizeof__()
-
-    def has_visium_uns_images(adata: ad.AnnData) -> bool:
-        return (
-            "spatial" in adata.uns and
-            [k for k in adata.uns["spatial"] if "is_single" not in k]
-        )
-
-    size = 0
-    attrs = list(["_X", "_obs", "_var"])
-    attrs_raw = list(["X", "var"])
-    attrs_multi = list(["_uns", "_obsm", "_varm", "varp", "_obsp", "_layers"])
-    if adata.raw:
-        adata_raw = adata.raw
-        attrs.extend(attrs_raw)
-        
-    for attr in attrs + attrs_multi:
-        if attr in attrs_multi:
-            keys = getattr(adata, attr).keys()
-            s = sum([get_size(getattr(adata, attr)[k]) for k in keys])
-        elif attr in attrs_raw:
-            s = get_size(getattr(adata_raw, attr))
-        else:
-            s = get_size(getattr(adata, attr))
-
-        if s > 0 and show_stratified:
-            if "_" not in attr:
-                str_attr = ".raw." + attr + " " * (13 - len(attr))
-            else:
-                str_attr = attr.replace("_", ".") + " " * (18 - len(attr))
-            print(f"Size of {str_attr}: {'%3.2f' % (s / (1024 ** 2))} MB")
-
-        size += s
-
-    if has_visium_uns_images(adata):
-        library_id = [k for k in adata.uns["spatial"].keys() if "is_single" not in k][0]
-        print("Visium image arrays:") if show_stratified else None
-        for image_name, image_array in adata.uns["spatial"][library_id]["images"].items():
-            s = get_size(image_array)
-            if show_stratified:
-                str_name = image_name + " " * (18 - len(image_name))
-                print(f"Size of {str_name}: {'%3.2f' % (s / (1024 ** 2))} MB")
-            size += s
-
-    return size
-
-
 @dataclass
 class Sizes:
     memory_size: int = 0

--- a/cellxgene_resources/curation_sample_code.ipynb
+++ b/cellxgene_resources/curation_sample_code.ipynb
@@ -86,7 +86,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "**Get size of AnnData object and its attributes, including raw and visium image arrays if they exist** <a class=\"anchor\" id=\"adata_size\"></a>"
+    "**Get size of AnnData object on disk and when loaded into memory** <a class=\"anchor\" id=\"adata_size\"></a>\n",
+    "\n",
+    "Reads h5ad/h5 header/metadata information to quickly view group/dataset info and calculate amount of RAM needed to fully load AnnData object into memory\n",
+    "\n",
+    "By default, will only print on-disk and in-memory sizes\n",
+    "\n",
+    "Set print_datasets=True to get h5/h5ad group/dataset information and in-memory size per dataset"
    ]
   },
   {
@@ -95,10 +101,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from cellxgene_mods import get_adata_size\n",
+    "from cellxgene_mods import calculate_adata_memory\n",
     "\n",
     "\n",
-    "get_adata_size(adata)"
+    "calculate_adata_memory(adata_path='/path/to/adata.h5ad', print_datasets=False)"
    ]
   },
   {
@@ -1002,7 +1008,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.1.undefined"
+   "version": "3.11.8"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Updating the curation_sample_code notebook to use the latest h5/h5ad memory calculation function, `calculate_adata_memory()` and removing the older function, `get_adata_size()`.  

The latest function reads a file path and returns size on disk and when fully loaded into memory. There's further instruction in the curation_sample_code notebook to enable more detailed print out of the data sizes for h5/h5ad attributes.