### PR TITLE
Tools 206 rename or add remaining tier1 optional fields

### DIFF
--- a/scripts/flattener.py
+++ b/scripts/flattener.py
@@ -508,7 +508,7 @@ def clean_obs(glob):
 	
 	add_units = {'tissue_section_thickness': 'tissue_section_thickness_units',
 				'suspension_dissociation_time': 'suspension_dissociation_time_units',
-				'library_starting_quantity': 'library_starting_quantity_units'}
+				'cell_number_loaded': 'cell_number_loaded_units'}
 	for field in add_units.keys():
 		if field in glob.cxg_obs.columns:
 			glob.cxg_obs[field] = glob.cxg_obs[field].astype(str) + " " + glob.cxg_obs[add_units[field]].astype(str)

--- a/scripts/flattener_mods/constants.py
+++ b/scripts/flattener_mods/constants.py
@@ -77,7 +77,7 @@ CELL_METADATA = {
 		'starting_quantity_units',
 		'@id',
 		'lab.institute_name',
-		'dbxrefs',
+		'dbxrefs'
 	],
 	'raw_matrix': [
 		'assembly',

--- a/scripts/flattener_mods/constants.py
+++ b/scripts/flattener_mods/constants.py
@@ -46,7 +46,8 @@ CELL_METADATA = {
 		'treatment_summary',
 		'growth_medium',
 		'genetic_modifications',
-		'@type'
+		'@type',
+		'date_obtained'
 		],
 	'tissue_section': [
 		'uuid',
@@ -76,12 +77,13 @@ CELL_METADATA = {
 		'starting_quantity_units',
 		'@id',
 		'lab.institute_name',
-		'dbxrefs'
+		'dbxrefs',
 	],
 	'raw_matrix': [
 		'assembly',
 		'genome_annotation',
-		'software'
+		'software',
+		'intronic_reads_counted'
 	],
 	'seq_run': [
 		'platform'
@@ -131,9 +133,13 @@ PROP_MAP = {
 	'sample_genetic_modifications': 'genetic_modifications',
 	'sample_menstrual_phase_at_collection': 'menstrual_phase_at_collection',
 	'sample_source': 'tissue_source',
+	'sample_date_obtained' : 'sample_collection_year',
 	'library_protocol_assay_ontology_term_id': 'assay_ontology_term_id',
 	'library_lab_institute_name': 'institute',
 	'library_protocol_end_bias': 'sequenced_fragment',
+	'library_dbxrefs' : 'library_id_repository',
+	'library_starting_quantity':'cell_number_loaded',
+	'library_starting_quantity_units':'cell_number_loaded_units',
 	'donor_sex': 'sex',
 	'sample_@type': 'tissue_type',
 	'donor_donor_id': 'donor_id',
@@ -154,6 +160,7 @@ PROP_MAP = {
 	'suspension_depleted_cell_types_term_name': 'suspension_depleted_cell_types',
 	'suspension_cell_depletion_factors': 'suspension_depletion_factors',
 	'suspension_tissue_handling_interval': 'tissue_handling_interval',
+	'suspension_percent_cell_viability':'cell_viability_percentage',
 	'antibody_oligo_sequence': 'barcode',
 	'antibody_source': 'vendor',
 	'antibody_product_ids': 'vender_product_ids',
@@ -164,8 +171,8 @@ PROP_MAP = {
 	'raw_matrix_software': 'alignment_software',
 	'raw_matrix_genome_annotation': 'gene_annotation_version',
 	'raw_matrix_assembly': 'reference_genome',
-	'seq_run_platform': 'sequencing_platform',
-	'library_dbxrefs' : 'library_id_repository'
+	'raw_matrix_intronic_reads_counted':'intronic_reads_counted',
+	'seq_run_platform': 'sequencing_platform'
 }
 
 GENCODE_MAP = {
@@ -221,6 +228,9 @@ SAMPLE_PRESERVATION_MAP = {
 OPTIONAL_COLUMNS = [
 	'alignment_software',
 	'cell_state',
+	'cell_viability_percentage',
+	'cell_number_loaded',
+	'cell_number_loaded_units',
 	'disease_state',
 	'donor_BMI_at_collection',
 	'donor_cause_of_death',
@@ -232,19 +242,17 @@ OPTIONAL_COLUMNS = [
 	'gene_annotation_version',
 	'genetic_modifications',
 	'growth_medium',
-	'library_starting_quantity',
-	'library_starting_quantity_units',
 	'menstrual_phase_at_collection',
 	'reference_genome',
 	'reported_diseases',
 	'sample_treatment_summary',
+	'sample_collection_year',
 	'sequencing_platform',
 	'suspension_dissociation_reagent',
 	'suspension_dissociation_time',
 	'suspension_dissociation_time_units',
 	'suspension_depleted_cell_types',
 	'suspension_derivation_process',
-	'suspension_percent_cell_viability',
 	'suspension_enriched_cell_types',
 	'suspension_enrichment_factors',
 	'suspension_depletion_factors', 
@@ -253,7 +261,8 @@ OPTIONAL_COLUMNS = [
 	'tissue_section_thickness_units',
 	'tissue_handling_interval',
 	'tyrer_cuzick_lifetime_risk',
-	'library_id_repository'
+	'library_id_repository',
+	'intronic_reads_counted'
 ]
 
 COLUMNS_TO_DROP = [

--- a/scripts/flattener_mods/gather.py
+++ b/scripts/flattener_mods/gather.py
@@ -231,9 +231,9 @@ def gather_metdata(obj_type, properties, values_to_add, objs, connection):
 		elif prop == 'date_obtained':
 			if value != constants.UNREPORTED_VALUE:
 				value = value.split('-')[0]
-				latkey = (obj_type + '_' + prop).replace('.', '_')
-				key = constants.PROP_MAP.get(latkey, latkey)
-				values_to_add[key] = value
+			latkey = (obj_type + '_' + prop).replace('.', '_')
+			key = constants.PROP_MAP.get(latkey, latkey)
+			values_to_add[key] = value
 		elif prop == 'intronic_reads_counted':
 			if value != constants.UNREPORTED_VALUE:
 				value = 'yes' if value else 'no'
@@ -318,6 +318,9 @@ def gather_pooled_metadata(obj_type, properties, values_to_add, objs, connection
 					if v == 'NCIT:C17998':
 						v = 'unknown'
 					value.append(v)
+				if prop == 'date_obtained':
+					if v != constants.UNREPORTED_VALUE:
+						v = v.split('-')[0]
 				if isinstance(v, list):
 					value.extend(v)
 				else:

--- a/scripts/flattener_mods/gather.py
+++ b/scripts/flattener_mods/gather.py
@@ -317,7 +317,6 @@ def gather_pooled_metadata(obj_type, properties, values_to_add, objs, connection
 				if prop == 'cell_ontology.term_id':
 					if v == 'NCIT:C17998':
 						v = 'unknown'
-					value.append(v)
 				if prop == 'date_obtained':
 					if v != constants.UNREPORTED_VALUE:
 						v = v.split('-')[0]

--- a/scripts/flattener_mods/gather.py
+++ b/scripts/flattener_mods/gather.py
@@ -32,6 +32,7 @@ def gather_rawmatrices(derived_from, connection):
 		'libraries',
 		'derived_from',
 		'software',
+		'intronic_reads_counted'
 	]
 	
 	obj_type, filter_lst = lattice.parse_ids(derived_from)
@@ -227,6 +228,18 @@ def gather_metdata(obj_type, properties, values_to_add, objs, connection):
 				if len(value_list) > 1:
 					value_list = sorted(value_list)
 				values_to_add[key] = ",".join(value_list)
+		elif prop == 'date_obtained':
+			if value != constants.UNREPORTED_VALUE:
+				value = value.split('-')[0]
+				latkey = (obj_type + '_' + prop).replace('.', '_')
+				key = constants.PROP_MAP.get(latkey, latkey)
+				values_to_add[key] = value
+		elif prop == 'intronic_reads_counted':
+			if value != constants.UNREPORTED_VALUE:
+				value = 'yes' if value else 'no'
+				latkey = (obj_type + '_' + prop).replace('.', '_')
+				key = constants.PROP_MAP.get(latkey, latkey)
+				values_to_add[key] = value
 		else:
 			if isinstance(value, list):
 				value = ','.join(value)


### PR DESCRIPTION
**library_starting_quanitity + _units changed to cell_number_loaded + _units**
- Changed values in prop_map and optional_columns in constants.py
- Tested on LATDF190KNY  

**suspension_percent_cell_viability changed to cell_viability_percentage**
- Added mapping to PROP_MAP in constants.py
- Replaced suspension_percent_cell viability with cell_viability_percentage in OPTIONAL_COLUMNS in constants.py 
- Tested on LATDF879UES

**tissue.date_obtained changed to sample_collection_year**
- Added date_obtained to sample part of cell_metadata
- Added map to ‘sample_collection_year’ to prop_map
- Added ‘sample_collection_year’ to optional_columns
- Added code to gather_metdata in gather.py to strip un-needed day and month info if present. 
- Tested on LATDF519CUZ (with dashes) and LATDF419ACG (without dashes)

**Adding intronic_reads_counted**
- added intronic_reads_counted to CELL_METADATA
- Added mapping to intronic_reads_counted to PROP_MAP in constants.py
- Added ‘intronic_reads_counted’ to gather_rawmatrices function in gather.py
- Added handling to gather_metdata to convert boolean. 
- Tested on LATDF190KNY

Note: MOVED dbxrefs in prop_map to be with other library terms, just for organizations sake. This might be why it cannot automatically merge?