### PR TITLE
Tools 219 comments for flattener testing

### DIFF
--- a/scripts/flattener_mods/constants.py
+++ b/scripts/flattener_mods/constants.py
@@ -179,7 +179,7 @@ PROP_MAP = {
 	'raw_matrix_genome_annotation': 'gene_annotation_version',
 	'raw_matrix_assembly': 'reference_genome',
 	'raw_matrix_intronic_reads_counted':'intronic_reads_counted',
-	'seq_run_platform': 'sequencing_platform'
+	'seq_run_platform': 'sequencing_platform',
 	'raw_seq_flowcell_details': 'library_sequencing_run'
 }
 

--- a/scripts/test_flattener.py
+++ b/scripts/test_flattener.py
@@ -10,8 +10,9 @@ DEFAULT_MATRIX_TXT = "test_processed_matrix_files.txt"
 EPILOG = f"""
 Script to test flattener in parallel.
 Will create new process per each ProcessedMatrixFile given as input
-Can provide txt file with name of one ProcessedMatrixFile per line or
-use -p/--processed-matrices argument to list ProcMatrixFiles on command line
+Can provide txt file with name of one ProcessedMatrixFile per line
+Txt file supports commented lines staring with '#' or inline comments with '#'
+Use -p/--processed-matrices argument to list ProcMatrixFiles on command line
 
 Final terminal print out will show either:
     ProcessedMatrixFile: SUCCESS
@@ -92,7 +93,7 @@ def make_file_list(args):
         return args.matrices
     else:
         with open(args.file, "r") as f:
-            return [line.strip() for line in f]
+            return [line.partition("#")[0].strip() for line in f if not line.startswith("#")]
 
 
 if __name__ == "__main__":

--- a/scripts/test_processed_matrix_files.txt
+++ b/scripts/test_processed_matrix_files.txt
@@ -1,10 +1,11 @@
-LATDF190KNY
-LATDF584NGT
-LATDF742BQI
-LATDF329OGL
-LATDF477OUM
-LATDF483VSD
-LATDF994BQY
-LATDF448PLU
-LATDF366MLP
-LATDF216UIK
+# standard processed matrix files for flattener testing
+LATDF190KNY     # multiple annotation versions
+LATDF584NGT     # Visium
+LATDF742BQI     # layers to keep, w/ + w/o rawseqfile
+LATDF329OGL     # Slide-seq, w/o rawseqfile
+LATDF477OUM     # pooled donors
+LATDF483VSD     # CITE data in rawmxfile, primary:False
+LATDF994BQY     # cell culture
+LATDF448PLU     # primary:mixed
+LATDF366MLP     # ATAC, ENSG index, w/o rawseqfile
+LATDF216UIK     # pooled experiments


### PR DESCRIPTION
Add support for comments within the flattener testing txt input file.

Before only one ProcessedMatrixFile per line, which makes it hard to remember why each file was chosen for testing. Now the standard processed matrix files in `test_processed_matrix_files.txt` are commented with the specifics for why they are used for testing.

Txt input files support comments that start with '#'. Anything to the right of the # will be ignored, so full line comments and inline comments are possible.

Also fixed syntax error in constants with this PR