### PR TITLE
Primary portion fix and exclude deprecated dev stage terms

### DIFF
--- a/scripts/flattener.py
+++ b/scripts/flattener.py
@@ -1225,19 +1225,6 @@ def main(mfinal_id, connection, hcatier1):
 	del cxg_adata_lst
 	gc.collect()
 
-	# Check that primary_portion.obs_field of ProcessedMatrixFile is present in cxg_obs
-	if glob.mfinal_obj.get('primary_portion', None): # Checking for presence of 'primary_portion'
-		primary_portion = glob.mfinal_obj.get('primary_portion')
-		if primary_portion.get('obs_field') not in glob.cxg_obs.columns:
-			logging.error("ERROR: 'obs_field' value '{}' not found in cxg_obs columns".format(primary_portion.get('obs_field')))
-			sys.exit("ERROR: 'obs_field' value '{}' not found in cxg_obs columns".format(primary_portion.get('obs_field')))
-
-		# Check that all primary_portion.values of ProcessedMatrixFile are found in the 'obs_field' column of cxg_obs
-		missing = [f for f in primary_portion.get('values') if f not in glob.cxg_obs[primary_portion.get('obs_field')].tolist()]
-		if missing:
-			logging.error("ERROR: cxg_obs column '{}' doesn't contain values present in 'primary_portion.obs_field' of ProcessedMatrixFile: {}".format(primary_portion.get('obs_field'),missing))
-			sys.exit("ERROR: cxg_obs column '{}' doesn't contain values present in 'primary_portion.obs_field' of ProcessedMatrixFile: {}".format(primary_portion.get('obs_field'),missing))
-
 	# Create cxg_var and merge relevant metadata
 	results_file  = get_results_filename(glob)
 	glob.mfinal_adata.var_names_make_unique()
@@ -1258,6 +1245,19 @@ def main(mfinal_id, connection, hcatier1):
 		hcatier1_check(glob)
 	drop_cols(celltype_col, glob)
 	clean_obs(glob)
+
+	# Check that primary_portion.obs_field of ProcessedMatrixFile is present in cxg_obs
+	if glob.mfinal_obj.get('primary_portion', None): # Checking for presence of 'primary_portion'
+		primary_portion = glob.mfinal_obj.get('primary_portion')
+		if primary_portion.get('obs_field') not in glob.cxg_obs.columns:
+			logging.error("ERROR: 'obs_field' value '{}' not found in cxg_obs columns".format(primary_portion.get('obs_field')))
+			sys.exit("ERROR: 'obs_field' value '{}' not found in cxg_obs columns".format(primary_portion.get('obs_field')))
+
+		# Check that all primary_portion.values of ProcessedMatrixFile are found in the 'obs_field' column of cxg_obs
+		missing = [f for f in primary_portion.get('values') if f not in glob.cxg_obs[primary_portion.get('obs_field')].tolist()]
+		if missing:
+			logging.error("ERROR: cxg_obs column '{}' doesn't contain values present in 'primary_portion.obs_field' of ProcessedMatrixFile: {}".format(primary_portion.get('obs_field'),missing))
+			sys.exit("ERROR: cxg_obs column '{}' doesn't contain values present in 'primary_portion.obs_field' of ProcessedMatrixFile: {}".format(primary_portion.get('obs_field'),missing))
 
 	# Add spatial information to adata.uns, which is assay dependent. Assumption is that the spatial dataset is from a single assay
 	if glob.mfinal_obj['assays'] == ['spatial transcriptomics']:

--- a/scripts/flattener_mods/gather.py
+++ b/scripts/flattener_mods/gather.py
@@ -345,7 +345,7 @@ def gather_pooled_metadata(obj_type, properties, values_to_add, objs, connection
 							logger.error('ERROR: There is no common development_slims that can be used for development_stage_ontology_term_id')
 							sys.exit("ERROR: There is no common development_slims that can be used for development_stage_ontology_term_id")
 						else:
-							obj = lattice.get_report('OntologyTerm','&term_name='+dev_in_all[0], ['term_id'], connection)
+							obj = lattice.get_report('OntologyTerm','&status!=deleted&term_name='+dev_in_all[0], ['term_id'], connection)
 							values_to_add[key] = obj[0].get('term_id')
 					elif key == 'sex':
 						values_to_add[key] = 'unknown'


### PR DESCRIPTION
See TOOLS-232 for further info.

Rearranged ordering of code for primary.portion that caused this error while flattening a dataset with an author column with primary_portion:
`ERROR: 'obs_field' value 'study_name' not found in cxg_obs columns`

Also added new parameter to query to exclude deprecated dev terms for pooled donor metadata.

Tested on ec2 instance on prod with the normal test files and these 3 processed matrix file that contain author columns with primary_portion:

- LATDF762QWB
- LATDF065UGW
 -LATDF879UES

Jennifer also successfully flattened the initial file with this fix: LATDF343OVF