### PR TITLE
TOOLS-238 for fields that have a value of an empty list, default value to unreported value

### DIFF
--- a/scripts/flattener.py
+++ b/scripts/flattener.py
@@ -581,9 +581,6 @@ def clean_obs(glob):
 
 # Drop any intermediate or optional fields that are all empty
 def drop_cols(celltype_col, glob):
-	if 'sequencing_platform' in glob.cxg_obs.columns:
-		if glob.cxg_obs['sequencing_platform'].isnull().values.any():
-			glob.cxg_obs['sequencing_platform'].fillna(fm.UNREPORTED_VALUE, inplace=True)
 	for col in fm.OPTIONAL_COLUMNS:
 		if col in glob.cxg_obs.columns.to_list():
 			col_content = glob.cxg_obs[col].unique()

--- a/scripts/flattener_mods/gather.py
+++ b/scripts/flattener_mods/gather.py
@@ -255,7 +255,10 @@ def gather_metdata(obj_type, properties, values_to_add, objs, connection):
 				values_to_add[key] = value
 		else:
 			if isinstance(value, list):
-				value = ','.join(value)
+				if len(value) == 0:
+					value = constants.UNREPORTED_VALUE
+				else:
+					value = ','.join(value)
 			latkey = (obj_type + '_' + prop).replace('.', '_')
 			key = constants.PROP_MAP.get(latkey, latkey)
 			values_to_add[key] = value
@@ -433,6 +436,8 @@ def gather_pooled_metadata(obj_type, properties, values_to_add, objs, connection
 						sys.exit(f"ERROR: Cxg field '{key}' is a list")
 				else:
 					values_to_add[key] = 'pooled [{}]'.format(','.join(value_str))
+			elif len(value_set) == 0:
+				values_to_add[key] = constants.UNREPORTED_VALUE
 			else:
 				values_to_add[key] = next(iter(value_set))
 


### PR DESCRIPTION
This fix allows fields, including 'sequencing_platform', to have empty lists as their value.

- Ran standard test set and looked at sequencing_platform, and returned valid values. 
- The current code on main will fail on DEMO for LATDF684CEO, which was the dataset that Jennifer was working on when she ran into an error. Current code on this branch will flattener correctly to sequencing_platform to "unknown"
- Also removed code for when sequencing_platform was being filled out manually rather than it's current implementation through checkfiles