### PR TITLE
TOOLS-243: Automate pathfinding for CXG repos and API keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,16 @@ Compiles studies from CELLxGENE, HCA Data Portal, HCA Publications, and Bionetwo
 * **upload_local.ipynb**
 Submitting local files to CELLxGENE<br>
 Please note: <br>
-    This script utilizes the [single-cell-curation](https://github.com/chanzuckerberg/single-cell-curation/tree/main) repo which should be cloned to the following directory `~/GitClones/CZI/` and CXG API keys should be stored in `~/Documents/keys/cxg-api-key.txt`
+    Local copies of the [single-cell-curation](https://github.com/chanzuckerberg/single-cell-curation/tree/main) repo and API keys should be stored in these locations:
+    * `~/GitClones/CZI/` 
+    * `~/Documents/keys/cxg-api-key.txt`
+    * Other locations where the script will search for repo and keys:
+        * `~/`
+        * `~/CZI/`
+        * `~/keys/`
+        * `~/Documents/`
+        * `~/GitClones/`
+    
 
 
 ### scripts/<br>*for curating towards or out of [Lattice DB](lattice-data.org)*

--- a/cellxgene_resources/cellxgene_mods.py
+++ b/cellxgene_resources/cellxgene_mods.py
@@ -78,27 +78,29 @@ def get_path(search_term: str) -> os.PathLike | str:
 
 
 class CxG_API:
-    scc_repo_loc = os.path.expanduser('~/GitClones/CZI/')
-    sys.path.append(os.path.abspath(scc_repo_loc + 'single-cell-curation/notebooks/curation_api/python/'))
+    scc_repo_loc = get_path("single-cell-curation")
 
+    if isinstance(scc_repo_loc, Path):
+        api_source = scc_repo_loc.resolve() / "notebooks" / "curation_api" / "python"
+        sys.path.append(str(api_source))
+    else:
+        print("Path not found for single-cell-curation repo")
+                
 
     from src.collection import create_collection,create_revision,get_collection,get_collections,update_collection
     from src.dataset import create_dataset,delete_dataset,get_dataset,get_datasets,upload_datafile_from_link,upload_local_datafile
 
-
-    def config(env=None):
+    def config(env="prod"):
         from src.utils.config import set_api_access_config
 
+        api_key_files = {
+            "prod": "cxg-api-key.txt",
+            "dev": "cxg-api-key-dev.txt",
+            "staging": "cxg-api-key-staging.txt",
+        }
 
-        if env == 'dev':
-            api_key_file_path = os.path.expanduser('~/Documents/keys/cxg-api-key-dev.txt')
-            set_api_access_config(api_key_file_path, env='dev')
-        elif env == 'staging':
-            api_key_file_path = os.path.expanduser('~/Documents/keys/cxg-api-key-staging.txt')
-            set_api_access_config(api_key_file_path, env='staging')
-        else:
-            api_key_file_path = os.path.expanduser('~/Documents/keys/cxg-api-key.txt')
-            set_api_access_config(api_key_file_path)
+        api_key_file_path = get_path(api_key_files[env])
+        set_api_access_config(api_key_file_path, env=env)
 
 
 def report(mess, level=None):

--- a/cellxgene_resources/cellxgene_mods.py
+++ b/cellxgene_resources/cellxgene_mods.py
@@ -59,13 +59,16 @@ def get_path(search_term: str) -> os.PathLike | str:
     local_path = Path()
     
     likely_locations = [
-        local_path.resolve().parent.parent,
+        local_path.resolve(),                               # same level
+        local_path.resolve().parent.parent,                 # same level as lattice-tools
         local_path.home(),
+        local_path.home() / "CZI",
         local_path.home() / "GitClones",
         local_path.home() / "GitClones" / "CZI",
-        local_path.home() / "GitClones" / "Lattice-Data",
+        local_path.home() / "GitClones" / "Lattice-Data",   # if other local lattice repos beyond lattice-tools
         local_path.home() / "Documents" / "keys",
-        local_path.home() / "keys"
+        local_path.home() / "keys",
+        local_path.home() / "Desktop" / "Curation",
     ]
 
     for place in likely_locations:

--- a/cellxgene_resources/cellxgene_mods.py
+++ b/cellxgene_resources/cellxgene_mods.py
@@ -59,7 +59,6 @@ def get_path(search_term: str) -> os.PathLike | str:
     local_path = Path()
     
     likely_locations = [
-        local_path.resolve(),                               # same level
         local_path.resolve().parent.parent,                 # same level as lattice-tools
         local_path.home(),
         local_path.home() / "CZI",

--- a/cellxgene_resources/cellxgene_mods.py
+++ b/cellxgene_resources/cellxgene_mods.py
@@ -11,6 +11,7 @@ import squidpy as sq
 import subprocess
 import sys
 from dataclasses import dataclass
+from pathlib import Path
 from scipy import sparse
 
 
@@ -45,6 +46,35 @@ portal_obs_fields = [
 non_ontology_fields = ['donor_id','suspension_type','tissue_type','is_primary_data']
 curator_obs_fields = [e + '_ontology_term_id' for e in portal_obs_fields] + non_ontology_fields
 full_obs_standards = portal_obs_fields + curator_obs_fields
+
+
+def get_path(search_term: str) -> os.PathLike | str:
+    """
+    Find path of local repos and API keys regardless of source machine. Use Path objects and
+    likely locations instead of glob or rglob to limit search overhead for simple import
+
+    Returns Path when found, otherwise str "Path not found"
+    """
+    # should start at ./lattice-tools/cellxgene_resources/
+    local_path = Path()
+    
+    likely_locations = [
+        local_path.resolve().parent.parent,
+        local_path.home(),
+        local_path.home() / "GitClones",
+        local_path.home() / "GitClones" / "CZI",
+        local_path.home() / "GitClones" / "Lattice-Data",
+        local_path.home() / "Documents" / "keys",
+        local_path.home() / "keys"
+    ]
+
+    for place in likely_locations:
+        if place.exists():
+            for item in place.iterdir():
+                if search_term in item.name:
+                    return item
+
+    return "Path not found"
 
 
 class CxG_API:

--- a/cellxgene_resources/cellxgene_mods.py
+++ b/cellxgene_resources/cellxgene_mods.py
@@ -68,6 +68,7 @@ def get_path(search_term: str) -> os.PathLike | str:
         local_path.home() / "GitClones" / "Lattice-Data",   # if other local lattice repos beyond lattice-tools
         local_path.home() / "Documents" / "keys",
         local_path.home() / "keys",
+        local_path.home() / "Documents",
         local_path.home() / "Desktop" / "Curation",
     ]
 


### PR DESCRIPTION
Currently, `cellxgene_mods.py` will look to `~/GitClones/CZI/` and  `~/Documents/keys/cxg-api-key.txt` to find local copies of these assets. Through time and with the use of cloud resources like JupyterHub and EC2 instances, this directory structure varies across machines. It becomes bothersome to manually update these paths when needing to switch branches, remotely pull new commits, etc. 

This implementation automates the process by looking in several likely places for the files and using `Path()` from the included `pathlib` library/module. These places cover all locations used by Lattice as polled last week, save locations that are directly within a local repository. There is a small risk to accidentally expose the keys through inadvertently adding them to a commit; hopefully with this update, the keys can be placed in one location outside of a repo and paths will not need to be manually changed.

Open to other suggestions or possibly using glob/recursive glob for a cleaner implementation, but that seemed to add anywhere from 10-20 seconds of time to search, where this setup is about instantaneous. 

Tested on local MacBook Pro, flattener ec2 instance, and JupyterHub, with various paths used. 