### PR TITLE
Tools 239 check presence of prefix suffix in procmatrixfile

### DIFF
--- a/scripts/flattener.py
+++ b/scripts/flattener.py
@@ -799,7 +799,6 @@ def hcatier1_check(glob):
 		glob.cxg_obs['library_sequencing_run'] = 'unknown'
 
 # Sanity check that all prefixes/suffixes are actually in ProcMatrixFile
-# NEED TO ADD CHECK FOR NO REDUNDANCY IN PREFIXES/SUFFIXES 
 def prefixes_suffixes_presence_and_duplicate_check(glob):
 	mfinal_cell_identifiers = glob.mfinal_adata.obs.index.to_list()
 	if glob.mfinal_obj.get('cell_label_location') == 'prefix':

--- a/scripts/flattener.py
+++ b/scripts/flattener.py
@@ -798,6 +798,32 @@ def hcatier1_check(glob):
 	else:
 		glob.cxg_obs['library_sequencing_run'] = 'unknown'
 
+# Sanity check that all prefixes/suffixes are actually in ProcMatrixFile
+# NEED TO ADD CHECK FOR NO REDUNDANCY IN PREFIXES/SUFFIXES 
+def prefixes_suffixes_presence_and_duplicate_check(glob):
+	mfinal_cell_identifiers = glob.mfinal_adata.obs.index.to_list()
+	if glob.mfinal_obj.get('cell_label_location') == 'prefix':
+		prefixes = []
+		for mapping_dict in glob.mfinal_obj['cell_label_mappings']:
+			prefixes.append(mapping_dict['label'])
+		if len(prefixes) != len(set(prefixes)):
+			logging.error('ERROR: There are duplicate mapping label prefixes present')
+			sys.exit('ERROR: There are duplicate mapping label prefixes present')
+		for prefix in prefixes:
+			if not any(i for i in mfinal_cell_identifiers if i.startswith(prefix)):
+				logging.error('ERROR: The following cell label mapping prefix is not found in the ProcMatrixFile: {}'.format(prefix))
+				sys.exit('ERROR: The following cell label mapping prefix is not found in the ProcMatrixFile: {}'.format(prefix))
+	elif glob.mfinal_obj.get('cell_label_location') == 'suffix':
+		suffixes = []
+		for mapping_dict in glob.mfinal_obj['cell_label_mappings']:
+			suffixes.append(mapping_dict['label'])
+		if len(suffixes) != len(set(suffixes)):
+			logging.error('ERROR: There are duplicate mapping label suffixes present')
+			sys.exit('ERROR: There are duplicate mapping label prefixes present')
+		for suffix in suffixes:
+			if not any(i for i in mfinal_cell_identifiers if i.endswith(suffix)):
+				logging.error('ERROR: The following cell label mapping suffix is not found in the ProcMatrixFile: {}'.format(suffix))
+				sys.exit('ERROR: The following cell label mapping suffix is not found in the ProcMatrixFile: {}'.format(suffix))
 
 def main(mfinal_id, connection, hcatier1):
 
@@ -851,6 +877,8 @@ def main(mfinal_id, connection, hcatier1):
 	mfinal_local_path = '{}/{}.{}'.format(fm.MTX_DIR, glob.mfinal_obj['accession'], file_ext)
 	glob.mfinal_adata = sc.read_h5ad(mfinal_local_path)
 	mfinal_cell_identifiers = glob.mfinal_adata.obs.index.to_list()
+
+	prefixes_suffixes_presence_and_duplicate_check(glob)
 
 	cxg_adata_lst = []
 	redundant = []
@@ -1008,7 +1036,8 @@ def main(mfinal_id, connection, hcatier1):
 				prefixes.remove(mapping_label) # Removing mapping_label prefix from list of all prefixes
 				# Checking to make sure none of the other prefixes contain the mapping_label prefix, if they do, then make sure there's no false match
 				if any(prefix.startswith(mapping_label) for prefix in prefixes):
-					mfinal_with_label = [i for i in mfinal_cell_identifiers if i.startswith(mapping_label) and not i.startswith(tuple(prefixes))]
+					false_matches = [prefix for prefix in prefixes if prefix.startswith(mapping_label)]
+					mfinal_with_label = [i for i in mfinal_cell_identifiers if i.startswith(mapping_label) and not i.startswith(tuple(false_matches))]
 				else:
 					mfinal_with_label = [i for i in mfinal_cell_identifiers if i.startswith(mapping_label)]
 			elif glob.mfinal_obj.get('cell_label_location') == 'suffix':

--- a/scripts/flattener.py
+++ b/scripts/flattener.py
@@ -799,15 +799,15 @@ def hcatier1_check(glob):
 		glob.cxg_obs['library_sequencing_run'] = 'unknown'
 
 # Sanity check that all prefixes/suffixes are actually in ProcMatrixFile
-def prefixes_suffixes_presence_and_duplicate_check(glob):
-	mfinal_cell_identifiers = glob.mfinal_adata.obs.index.to_list()
+def prefixes_suffixes_presence_and_duplicate_check(mfinal_cell_identifiers,glob):
 	if glob.mfinal_obj.get('cell_label_location') == 'prefix':
 		prefixes = []
 		for mapping_dict in glob.mfinal_obj['cell_label_mappings']:
 			prefixes.append(mapping_dict['label'])
 		if len(prefixes) != len(set(prefixes)):
-			logging.error('ERROR: There are duplicate mapping label prefixes present')
-			sys.exit('ERROR: There are duplicate mapping label prefixes present')
+			duplicated = pd.Series(prefixes)[pd.Series(prefixes).duplicated()].values
+			logging.error('ERROR: There are duplicate mapping label prefixes present: {}'.format(duplicated))
+			sys.exit('ERROR: There are duplicate mapping label prefixes present: {}'.format(duplicated))
 		for prefix in prefixes:
 			if not any(i for i in mfinal_cell_identifiers if i.startswith(prefix)):
 				logging.error('ERROR: The following cell label mapping prefix is not found in the ProcMatrixFile: {}'.format(prefix))
@@ -817,8 +817,9 @@ def prefixes_suffixes_presence_and_duplicate_check(glob):
 		for mapping_dict in glob.mfinal_obj['cell_label_mappings']:
 			suffixes.append(mapping_dict['label'])
 		if len(suffixes) != len(set(suffixes)):
-			logging.error('ERROR: There are duplicate mapping label suffixes present')
-			sys.exit('ERROR: There are duplicate mapping label prefixes present')
+			duplicated = pd.Series(suffixes)[pd.Series(suffixes).duplicated()].values
+			logging.error('ERROR: There are duplicate mapping label suffixes present: {}'.format(duplicated))
+			sys.exit('ERROR: There are duplicate mapping label prefixes present: {}'.format(duplicated))
 		for suffix in suffixes:
 			if not any(i for i in mfinal_cell_identifiers if i.endswith(suffix)):
 				logging.error('ERROR: The following cell label mapping suffix is not found in the ProcMatrixFile: {}'.format(suffix))
@@ -877,7 +878,7 @@ def main(mfinal_id, connection, hcatier1):
 	glob.mfinal_adata = sc.read_h5ad(mfinal_local_path)
 	mfinal_cell_identifiers = glob.mfinal_adata.obs.index.to_list()
 
-	prefixes_suffixes_presence_and_duplicate_check(glob)
+	prefixes_suffixes_presence_and_duplicate_check(mfinal_cell_identifiers, glob)
 
 	cxg_adata_lst = []
 	redundant = []


### PR DESCRIPTION
Added prefixes_suffixes_presence_and_duplicate_check method to flattener.py that checks for presence of all prefixes/suffixes in ProcMatrixFile, and gives appropriate error if any are not present or redundant (duplicate).

Added fix to issue with prefixes being substrings of other prefixes.

Tested by modifying LATDF645IBZ on demo, changed mapping labels to be duplicate, not in ProcMatrixFile.

Also ran test_flattener.py, but it's coming back with failures that don't seem related to these changes:
```
LATDF584NGT: FAILURE
anndata._io.utils.AnnDataReadError: Above error raised while reading key '/obs/__categories/orig.ident' of type <class 'h5py._hl.dataset.Dataset'> from /.
LATDF329OGL: FAILURE
anndata._io.utils.AnnDataReadError: Above error raised while reading key '/obs/__categories/celltype' of type <class 'h5py._hl.dataset.Dataset'> from /.

```