### PR TITLE
Tools 250 curation qa ntbok 53

### DIFF
--- a/cellxgene_resources/cellxgene_mods.py
+++ b/cellxgene_resources/cellxgene_mods.py
@@ -10,9 +10,11 @@ import scanpy as sc
 import squidpy as sq
 import subprocess
 import sys
+import requests
 from dataclasses import dataclass
 from pathlib import Path
 from scipy import sparse
+import cellxgene_schema.gencode as gencode
 
 
 portal_uns_fields = [
@@ -196,22 +198,29 @@ def determine_sparsity(x):
 def evaluate_sparsity(adata):
     max_sparsity = 0.5
 
+    valid = True
     sparsity = determine_sparsity(adata.X)
     report(f'X sparsity: {sparsity}')
     if sparsity > max_sparsity and type(adata.X) != sparse.csr_matrix:
-        report('X should be converted to sparse', 'WARNING')
+        report('X should be converted to sparse', 'ERROR')
+        valid = False
     
     if adata.raw:
         sparsity = determine_sparsity(adata.raw.X)
         report(f'raw.X sparsity: {sparsity}')
         if sparsity > max_sparsity and type(adata.raw.X) != sparse.csr_matrix:
-            report('raw.X should be converted to sparse', 'WARNING')
+            report('raw.X should be converted to sparse', 'ERROR')
+            valid = False
     
     for l in adata.layers:
         sparsity = determine_sparsity(adata.layers[l])
         report(f'layers[{l}] sparsity: {sparsity}')
         if sparsity > max_sparsity and type(adata.layers[l]) != sparse.csr_matrix:
-            report(f'layers[{l}] should be converted to sparse', 'WARNING')
+            report(f'layers[{l}] should be converted to sparse', 'ERROR')
+            valid = False
+
+    if valid:
+        report('all matrices are csr', 'GOOD')
 
 
 def evaluate_data(adata):
@@ -888,3 +897,61 @@ def evaluate_donors_sex(adata):
           )
 
         return donor_sex_df, dp
+
+
+def evaluate_var_df(adata):
+    """
+    Use single-cell-curation classes and fuctions and report warning/error for organism specific minimum number of gene features. Also, this function 
+    will look that var contains features from only a single organism.
+
+    :param obj adata: AnnData that is being curated
+
+    :return logging: Raises WARNING or ERROR if the number of genes in adata.var and adata.raw.var are fewer than the threshold of 40% or 60%, respectively,
+    of 10x preselected biotype of genes. Will also raise ERROR if dataset contains more than a singel organism.
+    """
+    accepted_biotypes = [
+        'protein_coding',
+        'protein_coding_LoF',
+        'lncRNA',
+        'IG_C_gene',
+        'IG_D_gene',
+        'IG_J_gene',
+        'IG_LV_gene',
+        'IG_V_gene',
+        'IG_V_pseudogene',
+        'IG_J_pseudogene',
+        'IG_C_pseudogene',
+        'TR_C_gene',
+        'TR_D_gene',
+        'TR_J_gene',
+        'TR_V_gene',
+        'TR_V_pseudogene',
+        'TR_J_pseudogene'
+    ]
+
+
+    # Check that this is single organism both in metadata and var index, exit function as does not make sense to check genes with multiple organisms
+    obs_organisms = adata.obs['organism_ontology_term_id'].unique()
+    var_organisms = {gencode.get_organism_from_feature_id(id).value for id in adata.var.index.to_list()}
+    if len(obs_organisms) > 1:
+        report(f'Multiple organisms found in obs metadata: {obs_organisms}', 'ERROR')
+        return
+    elif len(var_organisms) > 1:
+        report(f'Multiple organisms found in var index: {obs_organisms}', 'ERROR')
+        return
+    else:
+        report(f'Single organism found: {var_organisms}', 'GOOD')
+
+    # Check the number of genes threshold base on biotype per specific organism
+    organism = adata.obs['organism_ontology_term_id'].unique()[0]
+    org_obj = [i for i in gencode.SupportedOrganisms if i.value==organism][0]
+    gene_checker = gencode.GeneChecker(org_obj)
+    num_genes_biotype = len([i for i in gene_checker.gene_dict.keys() if gene_checker.gene_dict[i][2] in accepted_biotypes])
+
+    fraction = len(adata.var.index)/num_genes_biotype 
+    if fraction < 0.4:
+        report(f'only {len(adata.var.index)} out of {num_genes_biotype} 10x biotype genes, results in {fraction} (0.40 threshold)', 'ERROR')
+    elif fraction < 0.6:
+        report(f'{len(adata.var.index)} out of {num_genes_biotype} 10x biotype genes, results in {fraction} (0.60 threshold)','WARNING')
+    else:
+        report(f'{len(adata.var.index)} genes out of possible {num_genes_biotype} present', 'GOOD')

--- a/cellxgene_resources/cellxgene_mods.py
+++ b/cellxgene_resources/cellxgene_mods.py
@@ -220,7 +220,7 @@ def evaluate_sparsity(adata):
             valid = False
 
     if valid:
-        report('all matrices are csr', 'GOOD')
+        report('all matrices have passed checks', 'GOOD')
 
 
 def evaluate_data(adata):
@@ -931,14 +931,16 @@ def evaluate_var_df(adata):
 
 
     # Check that this is single organism both in metadata and var index, exit function as does not make sense to check genes with multiple organisms
-    obs_organisms = adata.obs['organism_ontology_term_id'].unique()
+    obs_organisms = adata.obs['organism_ontology_term_id'].unique().tolist()
     var_organisms = {gencode.get_organism_from_feature_id(id).value for id in adata.var.index.to_list()}
     if len(obs_organisms) > 1:
-        report(f'Multiple organisms found in obs metadata: {obs_organisms}', 'ERROR')
-        return
+        if 'NCBITaxon:2697049' not in obs_organisms:
+            report(f'Multiple organisms found in obs metadata: {obs_organisms}', 'ERROR')
+            return
     elif len(var_organisms) > 1:
-        report(f'Multiple organisms found in var index: {obs_organisms}', 'ERROR')
-        return
+        if 'NCBITaxon:2697049' not in obs_organisms:
+            report(f'Multiple organisms found in var index: {var_organisms}', 'ERROR')
+            return
     else:
         report(f'Single organism found: {var_organisms}', 'GOOD')
 
@@ -950,8 +952,8 @@ def evaluate_var_df(adata):
 
     fraction = len(adata.var.index)/num_genes_biotype 
     if fraction < 0.4:
-        report(f'only {len(adata.var.index)} out of {num_genes_biotype} 10x biotype genes, results in {fraction} (0.40 threshold)', 'ERROR')
+        report(f'{len(adata.var.index)} genes present, compared against {num_genes_biotype} 10x biotype genes; fraction: {fraction} (0.40 threshold)', 'ERROR')
     elif fraction < 0.6:
-        report(f'{len(adata.var.index)} out of {num_genes_biotype} 10x biotype genes, results in {fraction} (0.60 threshold)','WARNING')
+        report(f'{len(adata.var.index)} genes present, compared against {num_genes_biotype} 10x biotype genes, fraction: {fraction} (0.60 threshold)','WARNING')
     else:
-        report(f'{len(adata.var.index)} genes out of possible {num_genes_biotype} present', 'GOOD')
+        report(f'{len(adata.var.index)} genes present, compared against {num_genes_biotype} 10x biotype genes; fraction: {fraction}', 'GOOD')

--- a/cellxgene_resources/cellxgene_mods.py
+++ b/cellxgene_resources/cellxgene_mods.py
@@ -928,14 +928,12 @@ def evaluate_var_df(adata):
         'TR_J_pseudogene'
     ]
 
-
     # Check that this is single organism both in metadata and var index, exit function if multiple organisms or contains invalid var features
     var_organism_objs = list({gencode.get_organism_from_feature_id(id) for id in adata.var.index.to_list()})
     if None in var_organism_objs:
         report('Features in var.index are gene symbols and/or contain deprecated Ensembl IDs', 'ERROR')
         return
     valid = True
-    var_covid =False
     obs_organisms = adata.obs['organism_ontology_term_id'].unique().tolist()
     var_organisms = [o.value for o in var_organism_objs]
 

--- a/cellxgene_resources/cellxgene_mods.py
+++ b/cellxgene_resources/cellxgene_mods.py
@@ -202,21 +202,21 @@ def evaluate_sparsity(adata):
     sparsity = determine_sparsity(adata.X)
     report(f'X sparsity: {sparsity}')
     if sparsity > max_sparsity and type(adata.X) != sparse.csr_matrix:
-        report('X should be converted to sparse', 'ERROR')
+        report('X should be converted to csr sparse', 'ERROR')
         valid = False
     
     if adata.raw:
         sparsity = determine_sparsity(adata.raw.X)
         report(f'raw.X sparsity: {sparsity}')
         if sparsity > max_sparsity and type(adata.raw.X) != sparse.csr_matrix:
-            report('raw.X should be converted to sparse', 'ERROR')
+            report('raw.X should be converted to csr sparse', 'ERROR')
             valid = False
     
     for l in adata.layers:
         sparsity = determine_sparsity(adata.layers[l])
         report(f'layers[{l}] sparsity: {sparsity}')
         if sparsity > max_sparsity and type(adata.layers[l]) != sparse.csr_matrix:
-            report(f'layers[{l}] should be converted to sparse', 'ERROR')
+            report(f'layers[{l}] should be converted to csr sparse', 'ERROR')
             valid = False
 
     if valid:

--- a/cellxgene_resources/curation_qa.ipynb
+++ b/cellxgene_resources/curation_qa.ipynb
@@ -601,7 +601,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "if adata.obs['assay_ontology_term_id'].unique()[0] == 'EFO:0010961' and adata.uns['spatial']['is_single'] == True:\n",
+    "visium_assays = ['EFO:0022857','EFO:0022860','EFO:0022859']\n",
+    "if adata.obs['assay_ontology_term_id'].unique()[0].isin(visium_assays) and adata.uns['spatial']['is_single'] == True:\n",
     "    plot_vis(adata, cellpop_field)\n",
     "    if remove_colors:\n",
     "        del adata.uns[f'{cellpop_field}_colors']"

--- a/cellxgene_resources/curation_qa.ipynb
+++ b/cellxgene_resources/curation_qa.ipynb
@@ -602,7 +602,7 @@
    "outputs": [],
    "source": [
     "visium_assays = ['EFO:0022857','EFO:0022860','EFO:0022859']\n",
-    "if adata.obs['assay_ontology_term_id'].unique()[0].isin(visium_assays) and adata.uns['spatial']['is_single'] == True:\n",
+    "if adata.obs['assay_ontology_term_id'].unique()[0] in visium_assays and adata.uns['spatial']['is_single'] == True:\n",
     "    plot_vis(adata, cellpop_field)\n",
     "    if remove_colors:\n",
     "        del adata.uns[f'{cellpop_field}_colors']"

--- a/cellxgene_resources/curation_qa.ipynb
+++ b/cellxgene_resources/curation_qa.ipynb
@@ -465,10 +465,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "if len(adata.var) < 15000:\n",
-    "    report('Less than 15k genes present','ERROR')\n",
-    "elif len(adata.var) < 20000:\n",
-    "    report('Less than 20k genes present','WARNING')"
+    "evaluate_var_df(adata)"
    ]
   },
   {

--- a/cellxgene_resources/curation_visium.ipynb
+++ b/cellxgene_resources/curation_visium.ipynb
@@ -287,7 +287,7 @@
    "source": [
     "#REQUIRED - will be the same for all Visium V1 Datasets\n",
     "adata.obs['suspension_type'] = 'na'\n",
-    "adata.obs['assay_ontology_term_id'] = 'EFO:0010961' #EFO:0022859 for CytAssist 6.5mm or EFO:0022860 for CytAssist 11mm\n",
+    "adata.obs['assay_ontology_term_id'] = 'EFO:0022857' #EFO:0022859 for CytAssist 6.5mm or EFO:0022860 for CytAssist 11mm\n",
     "\n",
     "#REQUIRED - most likely the same value for all obs, update based on the given donor/sample\n",
     "adata.obs['donor_id'] = 'HDBR15773'\n",

--- a/cellxgene_resources/curation_visium.ipynb
+++ b/cellxgene_resources/curation_visium.ipynb
@@ -236,7 +236,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "if adata.obs.shape[0] < 4992:\n",
+    "spot_num = 4992 #This should be 14336 spots for Visium CytAssist 11mm\n",
+    "\n",
+    "if adata.obs.shape[0] < spot_num:\n",
     "    all_barcodes = pd.read_csv(sr_outs + '/spatial/tissue_positions_list.csv', header=None)\n",
     "    missing_barcodes = all_barcodes[all_barcodes[0].isin(list(adata.obs.index)) == False]\n",
     "    missing_barcodes.set_index(0, inplace=True)\n",
@@ -285,7 +287,7 @@
    "source": [
     "#REQUIRED - will be the same for all Visium V1 Datasets\n",
     "adata.obs['suspension_type'] = 'na'\n",
-    "adata.obs['assay_ontology_term_id'] = 'EFO:0010961'\n",
+    "adata.obs['assay_ontology_term_id'] = 'EFO:0010961' #EFO:0022859 for CytAssist 6.5mm or EFO:0022860 for CytAssist 11mm\n",
     "\n",
     "#REQUIRED - most likely the same value for all obs, update based on the given donor/sample\n",
     "adata.obs['donor_id'] = 'HDBR15773'\n",


### PR DESCRIPTION
Updated curation notebooks for the following:

- establish reasonable thresholds for gene counts for each organism & include those checks
- evaluate_sparsity() - looks like the check is correct (anything 50% sparse or more has to be sparse csr_matrix) but should be ERROR now instead of WARNING
- check that the gene IDs are from the organism in obs - ERROR for any with mixed organism in obs
- curation_visium.ipynb:
  - addition to adata.obs['assay_ontology_term_id'] to list out other possible assays for V2
  - update if adata.obs.shape[0] < 4992 to be assay specific

Current logic:
- if there is more than a single organism according to either the indices in var or organism_ontology_term_id in obs, `evaluate_var_df()` will report the error and then not go through with with number of genes. Please let me know if this behavior should be updated.
- the assumption is that adata.var and adata.raw.var will be matching, so looks only at adata.var

Things checked:
- Ran notebook using a correct AnnData, resulted in `GOOD:Single organism found: {'NCBITaxon:9606'}` and `GOOD:36387 genes out of possible 39583 present`
- Ran notebook using AnnData with < threshold genes for human, resulted in `ERROR:only 14000 out of 39583 10x biotype genes, results in 0.353687188944749 (0.40 threshold)`
- Ran notebook using AnnData with < threshold genes for human, resulted in `WARNING:17000 out of 39583 10x biotype genes, results in 0.42947730086148095 (0.60 threshold)`
- Ran notebook using AnnData with CSC matrix, resulted in `ERROR:X should be converted to csr sparse`
- Used AnnData with mixed organisms (mouse and human), resulted in: `ERROR:Multiple organisms found in obs metadata: ['NCBITaxon:9606', 'NCBITaxon:10090']`