### PR TITLE
upload to cxg via manifest

### DIFF
--- a/cellxgene_resources/cellxgene_mods.py
+++ b/cellxgene_resources/cellxgene_mods.py
@@ -91,7 +91,7 @@ class CxG_API:
                 
 
     from src.collection import create_collection,create_revision,get_collection,get_collections,update_collection
-    from src.dataset import create_dataset,delete_dataset,get_dataset,get_datasets,upload_datafile_from_link,upload_local_datafile
+    from src.dataset import create_dataset,delete_dataset,get_dataset,get_datasets,upload_datafile_from_link,upload_local_datafile,upload_datafiles_from_manifest,get_dataset_manifest
 
     def config(env="prod"):
         from src.utils.config import set_api_access_config

--- a/cellxgene_resources/upload_local.ipynb
+++ b/cellxgene_resources/upload_local.ipynb
@@ -155,7 +155,10 @@
     "for f,d in datasets.items():\n",
     "    if d == 'new':\n",
     "        d = CxG_API.create_dataset(collection_id)\n",
-    "    CxG_API.upload_local_datafile(f, collection_id, d)"
+    "    manifest = {\n",
+    "        'anndata': CxG_API.upload_local_datafile(f, collection_id, d)\n",
+    "    }\n",
+    "    CxG_API.upload_datafiles_from_manifest(manifest, collection_id, d)"
    ]
   },
   {


### PR DESCRIPTION
This doesn't include fragments file upload, which requires an additional entry in the manifest. Just might get messy when trying to account for fresh upload of new h5ad + fragments vs adding fragments to h5ad already uploaded
So will consider options for including those & submit a separate PR, but much less urgent