### PR TITLE
fix susp type bug

### DIFF
--- a/scripts/DCP_mapper.py
+++ b/scripts/DCP_mapper.py
@@ -895,6 +895,8 @@ def customize_fields(obj, obj_type, dataset_id, docid_updates):
 			del obj['red_blood_cell_lysis']
 		if obj.get('enrichment_factors'):
 			del obj['enrichment_factors']
+		if obj.get('suspension_type'):
+			del obj['suspension_type']
 		if obj.get('cell_morphology'):
 			if obj['cell_morphology'].get('cell_size'):
 				obj['cell_morphology']['cell_size'] = str(obj['cell_morphology']['cell_size'])

--- a/scripts/DCP_mods/property_mapping.py
+++ b/scripts/DCP_mods/property_mapping.py
@@ -431,6 +431,9 @@ lattice_to_dcp = {
 		'estimated_count_units': { # deleted before report
 			'lattice': 'starting_quantity_units'
 		},
+		'suspension_type': { # deleted before report
+			'lattice': 'suspension_type'
+		},
 		'growth_conditions.culture_environment': {
 			'lattice': 'medium'
 		},


### PR DESCRIPTION
There was a gap where some Suspension objects would need the suspension_type for a protocol description.
Fix was to map this in from Lattice then delete later in the process