### PR TITLE
fix bug for looking at barcodes for barcode checker

### DIFF
--- a/cellxgene_resources/cellxgene_mods.py
+++ b/cellxgene_resources/cellxgene_mods.py
@@ -339,7 +339,7 @@ def evaluate_10x_barcodes(obs, visium=False):
 
     obs = obs.copy()
     obs['barcode'] = obs.index.str.extract(r'([ACTG]{12,})')[0].tolist()
-    if len(set(ref_df.index.to_list()).intersection(set(obs.index.to_list()))) == 0:
+    if len(set(ref_df.index.to_list()).intersection(set(obs['barcode'].to_list()))) == 0:
         report('Did not find any barcodes in obs index, cannot evaluate barcodes', 'WARNING')
         return
     obs = obs.merge(ref_df[['summary']],on='barcode',how='left').set_index(obs.index)
@@ -352,6 +352,8 @@ def evaluate_10x_barcodes(obs, visium=False):
 
 
 def parse_barcode_df(df, field):
+    if df is None:
+        return
     results = {}
 
     for a in df[field].unique():

--- a/cellxgene_resources/curation_qa.ipynb
+++ b/cellxgene_resources/curation_qa.ipynb
@@ -320,8 +320,7 @@
     "assay_field = 'assay' if cxg_labels else 'assay_ontology_term_id'\n",
     "\n",
     "barcode_df = evaluate_10x_barcodes(adata.obs)\n",
-    "if barcode_df:\n",
-    "    parse_barcode_df(barcode_df, assay_field)"
+    "parse_barcode_df(barcode_df, assay_field)"
    ]
   },
   {


### PR DESCRIPTION
Things to note:
- I've updated `evaluate_10x_barcodes()` to look at obs['barcode'] for the warning. 
- I've also just moved the check for `barcode_df` for None into `parse_barcode_df()` so to avoid any complications of printing to screen in if-statement in the notebook

Tested:
- adata that with barcodes
- adata without barcodes: "WARNING: Did not find any barcodes in obs index, cannot evaluate barcodes"
 