### PR TITLE
Tools 261 move organism to uns

### DIFF
--- a/scripts/flattener.py
+++ b/scripts/flattener.py
@@ -601,7 +601,7 @@ def add_labels(glob):
 	obj = lattice.get_report('OntologyTerm', '', ['term_id', 'term_name'], glob.connection)
 	ontology_df = pd.DataFrame(obj)
 	id_cols = ['assay_ontology_term_id', 'disease_ontology_term_id', 'cell_type_ontology_term_id', 'development_stage_ontology_term_id', 'sex_ontology_term_id',\
-			'tissue_ontology_term_id', 'organism_ontology_term_id', 'self_reported_ethnicity_ontology_term_id']
+			'tissue_ontology_term_id', 'self_reported_ethnicity_ontology_term_id']
 	for col in id_cols:
 		name_col = col.replace("_ontology_term_id", "")
 		glob.cxg_adata.obs[name_col] = glob.cxg_adata.obs[col]
@@ -1092,12 +1092,13 @@ def main(mfinal_id, connection, hcatier1):
 	ds_results = fm.gather_metdata('matrix', fm.DATASET_METADATA['final_matrix'], ds_results, [glob.mfinal_obj], glob.connection)
 	df['is_primary_data'] = ds_results['is_primary_data']
 	df['is_primary_data'].replace({'True': True, 'False': False}, inplace=True)
+	ds_results['organism_ontology_term_id'] = df['organism_ontology_term_id'].unique()[0]
+	del ds_results['is_primary_data']
+	del df['organism_ontology_term_id']
 
 	# Check if default_embedding is unreported_value, and if so remove
 	if ds_results['default_embedding'] == fm.UNREPORTED_VALUE:
 		del ds_results['default_embedding']
-
-	del ds_results['is_primary_data']
 
 	# Should add error checking to make sure all matrices have the same number of vars
 	feature_lengths = []
@@ -1261,8 +1262,7 @@ def main(mfinal_id, connection, hcatier1):
 	var_meta = glob.mfinal_adata.var.select_dtypes(include=keep_types)
 
 	# Copy over adata.uns
-	reserved_uns = ['schema_version', 'title', 'default_embedding', 'X_approximate_distribution', 'schema_reference', 'citation']
-	fm.copy_over_uns(glob, reserved_uns)
+	fm.copy_over_uns(glob, fm.RESERVED_UNS)
 
 	# Check hcatier1 fields if flag is true and then clean up obs
 	if hcatier1:

--- a/scripts/flattener_mods/__init__.py
+++ b/scripts/flattener_mods/__init__.py
@@ -1,3 +1,3 @@
 from flattener_mods.gather import gather_rawmatrices, gather_objects, gather_metdata, gather_pooled_metadata, get_value, download_file
-from flattener_mods.constants import UNREPORTED_VALUE, SCHEMA_VERSION, MTX_DIR, REF_FILES, CELL_METADATA, DATASET_METADATA, ANNOT_FIELDS, ANTIBODY_METADATA, PROP_MAP, GENCODE_MAP, SAMPLE_COLLECTION_MAP, SAMPLE_PRESERVATION_MAP, OPTIONAL_COLUMNS, COLUMNS_TO_DROP
+from flattener_mods.constants import UNREPORTED_VALUE, SCHEMA_VERSION, MTX_DIR, REF_FILES, CELL_METADATA, DATASET_METADATA, ANNOT_FIELDS, ANTIBODY_METADATA, PROP_MAP, GENCODE_MAP, SAMPLE_COLLECTION_MAP, SAMPLE_PRESERVATION_MAP, OPTIONAL_COLUMNS, COLUMNS_TO_DROP, RESERVED_UNS
 from flattener_mods.uns_functions import colors_check, check_not_empty, copy_over_uns, process_spatial

--- a/scripts/flattener_mods/constants.py
+++ b/scripts/flattener_mods/constants.py
@@ -308,3 +308,13 @@ ACCEPTED_ACCESSIONS = {
 	'ENA:ERX'
 }
 
+RESERVED_UNS = [
+	'schema_version',
+	'title',
+	'default_embedding',
+	'X_approximate_distribution',
+	'schema_reference',
+	'citation',
+	'organism_ontology_term_id',
+	'organism'
+]

--- a/scripts/flattener_mods/gather.py
+++ b/scripts/flattener_mods/gather.py
@@ -405,7 +405,7 @@ def gather_pooled_metadata(obj_type, properties, values_to_add, objs, connection
 			key = constants.PROP_MAP.get(latkey, latkey)
 			value_str = [str(i) for i in value]
 			value_set = set(value_str)
-			cxg_fields = ['donor_diseases_term_id', 'library_id_repository','sex'\
+			cxg_fields = ['donor_diseases_term_id', 'library_id_repository','sex',\
 							 'tissue_ontology_term_id', 'development_stage_ontology_term_id']
 			if len(value_set) > 1:
 				donor_id = values_to_add.get('donor_id', 'unknown donor_id')

--- a/scripts/flattener_mods/gather.py
+++ b/scripts/flattener_mods/gather.py
@@ -405,8 +405,8 @@ def gather_pooled_metadata(obj_type, properties, values_to_add, objs, connection
 			key = constants.PROP_MAP.get(latkey, latkey)
 			value_str = [str(i) for i in value]
 			value_set = set(value_str)
-			cxg_fields = ['donor_diseases_term_id', 'organism_ontology_term_id', 'library_id_repository',\
-							 'sex', 'tissue_ontology_term_id', 'development_stage_ontology_term_id']
+			cxg_fields = ['donor_diseases_term_id', 'library_id_repository','sex'\
+							 'tissue_ontology_term_id', 'development_stage_ontology_term_id']
 			if len(value_set) > 1:
 				donor_id = values_to_add.get('donor_id', 'unknown donor_id')
 				if key in cxg_fields:


### PR DESCRIPTION
Ran standard test datasets in test_processed_matrix_files.txt and all moved organism_ontology_term_id to adata.uns.