### PR TITLE
Tools 259 allow disease lists

### DIFF
--- a/scripts/flattener.py
+++ b/scripts/flattener.py
@@ -149,7 +149,7 @@ def clean_list(lst, exp_disease, glob):
 	disease_found = [i for i in exp_disease_list if i in lst]
 	if disease_found:
 		if len(disease_found) > 1:
-			disease = ' || '.join(disease_found.split(','))
+			disease = ' || '.join(disease_found)
 		else:
 			disease = disease_found[0]
 	else:

--- a/scripts/flattener.py
+++ b/scripts/flattener.py
@@ -144,7 +144,7 @@ def quality_check(glob):
 
 # Return value to be stored in disease field based on list of diseases from donor and sample
 def clean_list(lst, exp_disease, glob):
-	lst = lst.split(',')
+	lst = lst.split(' || ')
 	exp_disease_list = [i['term_id'] for i in exp_disease]
 	disease_found = [i for i in exp_disease_list if i in lst]
 	if disease_found:
@@ -178,8 +178,8 @@ def concat_list(anndata_list, column, uns_merge):
 
 # Determine reported disease as unique of sample and donor diseases, removing unreported value
 def report_diseases(mxr_df, exp_disease, glob):
-	mxr_df['reported_diseases'] = mxr_df['sample_diseases_term_name'] + ',' + mxr_df['donor_diseases_term_name']
-	mxr_df['reported_diseases'] = mxr_df['reported_diseases'].apply(lambda x: '[{}]'.format(','.join([i for i in set(x.split(',')) if i!=fm.UNREPORTED_VALUE])))
+	mxr_df['reported_diseases'] = mxr_df['sample_diseases_term_name'] + ' || ' + mxr_df['donor_diseases_term_name']
+	mxr_df['reported_diseases'] = mxr_df['reported_diseases'].apply(lambda x: '[{}]'.format(' || '.join([i for i in set(x.split(' || ')) if i!=fm.UNREPORTED_VALUE])))
 	total_reported = mxr_df['reported_diseases'].unique()
 	if len(total_reported) == 1:
 		if total_reported[0] == '[]':
@@ -190,7 +190,7 @@ def report_diseases(mxr_df, exp_disease, glob):
 	if exp_disease == fm.UNREPORTED_VALUE:
 		mxr_df['disease_ontology_term_id'] = ['PATO:0000461'] * len(mxr_df.index)
 	else:
-		mxr_df['disease_ontology_term_id'] = mxr_df['sample_diseases_term_id'] + ',' + mxr_df['donor_diseases_term_id']
+		mxr_df['disease_ontology_term_id'] = mxr_df['sample_diseases_term_id'] + ' || ' + mxr_df['donor_diseases_term_id']
 		mxr_df['disease_ontology_term_id'] = mxr_df['disease_ontology_term_id'].apply(clean_list, exp_disease=exp_disease, glob=glob)
 		exp_disease_aslist = ['[{}]'.format(x['term_name']) for x in exp_disease]
 		exp_disease_aslist.extend(['none', '[]'])

--- a/scripts/flattener.py
+++ b/scripts/flattener.py
@@ -144,13 +144,14 @@ def quality_check(glob):
 
 # Return value to be stored in disease field based on list of diseases from donor and sample
 def clean_list(lst, exp_disease, glob):
-	lst = lst.split(' || ')
+	lst = lst.split(',')
 	exp_disease_list = [i['term_id'] for i in exp_disease]
 	disease_found = [i for i in exp_disease_list if i in lst]
 	if disease_found:
-		disease = disease_found[0]
 		if len(disease_found) > 1:
-			glob.warnings.append("WARNING: There is at least one sample with more than one experimental variable disease:\t{}".format(disease_found))
+			disease = ' || '.join(disease_found.split(','))
+		else:
+			disease = disease_found[0]
 	else:
 		disease = 'PATO:0000461'
 	return disease
@@ -178,8 +179,8 @@ def concat_list(anndata_list, column, uns_merge):
 
 # Determine reported disease as unique of sample and donor diseases, removing unreported value
 def report_diseases(mxr_df, exp_disease, glob):
-	mxr_df['reported_diseases'] = mxr_df['sample_diseases_term_name'] + ' || ' + mxr_df['donor_diseases_term_name']
-	mxr_df['reported_diseases'] = mxr_df['reported_diseases'].apply(lambda x: '[{}]'.format(' || '.join([i for i in set(x.split(' || ')) if i!=fm.UNREPORTED_VALUE])))
+	mxr_df['reported_diseases'] = mxr_df['sample_diseases_term_name'] + ',' + mxr_df['donor_diseases_term_name']
+	mxr_df['reported_diseases'] = mxr_df['reported_diseases'].apply(lambda x: '[{}]'.format(','.join([i for i in set(x.split(',')) if i!=fm.UNREPORTED_VALUE])))
 	total_reported = mxr_df['reported_diseases'].unique()
 	if len(total_reported) == 1:
 		if total_reported[0] == '[]':
@@ -190,7 +191,7 @@ def report_diseases(mxr_df, exp_disease, glob):
 	if exp_disease == fm.UNREPORTED_VALUE:
 		mxr_df['disease_ontology_term_id'] = ['PATO:0000461'] * len(mxr_df.index)
 	else:
-		mxr_df['disease_ontology_term_id'] = mxr_df['sample_diseases_term_id'] + ' || ' + mxr_df['donor_diseases_term_id']
+		mxr_df['disease_ontology_term_id'] = mxr_df['sample_diseases_term_id'] + ',' + mxr_df['donor_diseases_term_id']
 		mxr_df['disease_ontology_term_id'] = mxr_df['disease_ontology_term_id'].apply(clean_list, exp_disease=exp_disease, glob=glob)
 		exp_disease_aslist = ['[{}]'.format(x['term_name']) for x in exp_disease]
 		exp_disease_aslist.extend(['none', '[]'])

--- a/scripts/flattener_mods/gather.py
+++ b/scripts/flattener_mods/gather.py
@@ -223,28 +223,6 @@ def gather_metdata(obj_type, properties, values_to_add, objs, connection):
 				latkey = (obj_type + '_' + prop).replace('.','_')
 				key = constants.PROP_MAP.get(latkey, latkey)
 				values_to_add[key] = value
-		elif prop == 'diseases.term_id':
-			if value != None:
-				if isinstance(value, list):
-					if len(value) == 0:
-						value = constants.UNREPORTED_VALUE
-					else:
-						value.sort()
-						value = ' || '.join(value)
-				latkey = (obj_type + '_' + prop).replace('.','_')
-				key = constants.PROP_MAP.get(latkey, latkey)
-				values_to_add[key] = value
-		elif prop == 'diseases.term_name':
-			if value != None:
-				if isinstance(value, list):
-					if len(value) == 0:
-						value = constants.UNREPORTED_VALUE
-					else:
-						value.sort()
-						value = ' || '.join(value)
-				latkey = (obj_type + '_' + prop).replace('.','_')
-				key = constants.PROP_MAP.get(latkey, latkey)
-				values_to_add[key] = value
 		elif prop == 'cell_ontology.term_id':
 			if value == 'NCIT:C17998':
 				value = 'unknown'
@@ -406,13 +384,12 @@ def gather_pooled_metadata(obj_type, properties, values_to_add, objs, connection
 				ident = obj.get('@id')
 				v = get_value(obj, prop)
 				if isinstance(v, list):
-					v.sort()
 					if len(v) == 1 and v[0] == 'unknown':
 						values_df.loc[key,ident] = 'unknown'
 					elif 'unknown' in v:
 						values_df.loc[key,ident] = 'unknown'
 					else:
-						value = ' || '.join(v)
+						value = ','.join(v)
 						values_df.loc[key,ident] = value
 				else:
 					if v != constants.UNREPORTED_VALUE:
@@ -435,13 +412,12 @@ def gather_pooled_metadata(obj_type, properties, values_to_add, objs, connection
 				ident = obj.get('@id')
 				v = get_value(obj, prop)
 				if isinstance(v, list):
-					v.sort() # Needed for set() checks to be accurate
 					if len(v) == 1 and v[0] == 'unknown':
 						values_df.loc[key,ident] = 'unknown'
 					elif 'unknown' in v:
 						values_df.loc[key,ident] = 'unknown'
 					else:
-						value = ' || '.join(v)
+						value = ','.join(v)
 						values_df.loc[key,ident] = value
 				else:
 					if v != constants.UNREPORTED_VALUE:
@@ -451,7 +427,6 @@ def gather_pooled_metadata(obj_type, properties, values_to_add, objs, connection
 			disease_set = set(values_df.loc[key].to_list())
 			if len(disease_set) > 1:
 				values_to_add[key] = constants.UNREPORTED_VALUE
-				print(f"WARNING: Pooled disease term names '{disease_set}' for '{donor_id}', setting to 'unknown'")
 			else:
 				values_to_add[key] = disease_set.pop()
 		else:


### PR DESCRIPTION
Change disease handling to allow for disease lists.

gather_pooled_metadata was modified to update unknown check to handle lists for both diseases.term_id and diseases.term_name. Also removed old multiple values check and warning.

clean_list was modified to allow disease_ontology_term_id to be a list if disease_found is a list.

Tested for non-pooled on mocked file on demo (LATDF006UTH) where experimental disease was set to a list of values that some of the donors also had contained in the list of reported diseases.

For pooled handling, modified all donors in a library in LATDF675NTY to have multiple diseases, and then set experimental disease to same list. Result was as expected, presence of || separated string containg both diseases term ids.