### PR TITLE
DCP - remove library_prep_id from metadata

### DIFF
--- a/scripts/DCP_mapper.py
+++ b/scripts/DCP_mapper.py
@@ -967,11 +967,6 @@ def customize_fields(obj, obj_type, dataset_id, docid_updates):
 		else:
 			del obj['insdc_run_accessions']
 
-		if obj.get('library_prep_id'):
-			lib_id = obj['library_prep_id'][0]
-			lib_obj = lattice.get_report('Library',f'&@id={lib_id}',['uuid'],connection)[0]
-			obj['library_prep_id'] = lib_obj['uuid']
-
 	elif obj_type == 'supplementary_file':
 		file_format = obj['file_core']['file_name'].split('.')[-1]
 		obj['file_core']['format'] = file_format

--- a/scripts/DCP_mods/property_mapping.py
+++ b/scripts/DCP_mods/property_mapping.py
@@ -530,9 +530,6 @@ lattice_to_dcp = {
 		'insdc_run_accessions': {
 			'lattice': 'derived_from' # DCP_mapper pulls out just dbxrefs
 		},
-		'library_prep_id': {
-			'lattice': 'libraries'
-		},
 		'provenance.document_id': {
 			'lattice': 'uuid'
 		},


### PR DESCRIPTION
drop library_prep_id from sequence_files to DCP