### PR TITLE
Tools 272 multiplexed organism error

### DIFF
--- a/cellxgene_resources/cellxgene_mods.py
+++ b/cellxgene_resources/cellxgene_mods.py
@@ -934,13 +934,14 @@ def evaluate_donors_sex(adata):
 
 def evaluate_var_df(adata):
     """
-    Use single-cell-curation classes and fuctions and report warning/error for organism specific minimum number of gene features. Also, this function 
+    Use single-cell-curation classes and fuctions and report warning/error for organism specific minimum number of gene features. Also, this function
     will look that var contains features from only a single organism.
 
     :param obj adata: AnnData that is being curated
 
     :return logging: Raises WARNING or ERROR if the number of genes in adata.var and adata.raw.var are fewer than the threshold of 40% or 60%, respectively,
-    of 10x preselected biotype of genes. Will also raise ERROR if dataset contains more than a singel organism.
+    of 10x preselected biotype of genes. Will also raise ERROR if dataset contains more than a single organism; and raise a WARNING if the dataset has 50% or
+    more genes filtered.
     """
     accepted_biotypes = [
         'protein_coding',
@@ -1017,3 +1018,13 @@ def evaluate_var_df(adata):
         report(f'{len(adata.var.index)} genes present, compared against {num_genes_biotype} 10x biotype genes, fraction: {fraction} (0.60 threshold)','WARNING')
     else:
         report(f'{len(adata.var.index)} genes present, compared against {num_genes_biotype} 10x biotype genes; fraction: {fraction}', 'GOOD')
+
+    # Check the number of filtered genes
+    if 'feature_is_filtered' in adata.var.columns:
+        num_filtered_genes = len(adata.var[adata.var.feature_is_filtered == True])
+        if num_filtered_genes/len(adata.var.index) >= 0.5:
+            report(f'50% or more genes are filtered', 'WARNING')
+        else:
+            report(f'Less than 50% of genes are filtered', 'GOOD')
+    else:
+        report('feature_is_filtered not found in var', 'WARNING')

--- a/scripts/flattener.py
+++ b/scripts/flattener.py
@@ -1139,9 +1139,7 @@ def main(mfinal_id, connection, hcatier1):
 	ds_results = fm.gather_metdata('matrix', fm.DATASET_METADATA['final_matrix'], ds_results, [glob.mfinal_obj], glob.connection)
 	df['is_primary_data'] = ds_results['is_primary_data']
 	df['is_primary_data'].replace({'True': True, 'False': False}, inplace=True)
-	ds_results['organism_ontology_term_id'] = df['organism_ontology_term_id'].unique()[0]
 	del ds_results['is_primary_data']
-	del df['organism_ontology_term_id']
 
 	# Check if default_embedding is unreported_value, and if so remove
 	if ds_results['default_embedding'] == fm.UNREPORTED_VALUE:
@@ -1316,6 +1314,8 @@ def main(mfinal_id, connection, hcatier1):
 		hcatier1_check(glob)
 	drop_cols(celltype_col, glob)
 	clean_obs(glob)
+	glob.cxg_uns['organism_ontology_term_id'] = glob.cxg_obs['organism_ontology_term_id'].unique()[0]
+	del glob.cxg_obs['organism_ontology_term_id']
 
 	# Check that primary_portion.obs_field of ProcessedMatrixFile is present in cxg_obs
 	if glob.mfinal_obj.get('primary_portion', None): # Checking for presence of 'primary_portion'

--- a/scripts/test_processed_matrix_files.txt
+++ b/scripts/test_processed_matrix_files.txt
@@ -9,3 +9,4 @@ LATDF994BQY     # cell culture
 LATDF448PLU     # primary:mixed
 LATDF366MLP     # ATAC, ENSG index, w/o rawseqfile
 LATDF216UIK     # pooled experiments
+LATDF642PEG     # demultiplexed experiment


### PR DESCRIPTION
Here's the fix for the determining organism for demultiplexed experiments. I have also added LATDF642PEG (demultiplexed dataset) to the standard testing datasets. Ran standard set and all passed:

```
FINAL RESULTS:
================================================================================
LATDF190KNY: SUCCESS
LATDF584NGT: SUCCESS
LATDF742BQI: SUCCESS
LATDF329OGL: SUCCESS
LATDF477OUM: SUCCESS
LATDF483VSD: SUCCESS
LATDF994BQY: SUCCESS
LATDF448PLU: SUCCESS
LATDF366MLP: SUCCESS
LATDF216UIK: SUCCESS
LATDF642PEG: SUCCESS 
```