### PR TITLE
Moving value assignment to within if statement checking for unreporte…

### DIFF
--- a/scripts/flattener_mods/gather.py
+++ b/scripts/flattener_mods/gather.py
@@ -440,7 +440,7 @@ def gather_pooled_metadata(obj_type, properties, values_to_add, objs, connection
 								db_ids.append(db_id[4:])
 						if len(db_ids) > 1:
 							db_ids = sorted(db_ids)
-					v = db_ids
+						v = db_ids
 				if isinstance(v, list):
 					value.extend(v)
 				else:


### PR DESCRIPTION
Running a processed matrix file with libraries that had 'unknown' for dbxref resulted in the following error:
`Traceback (most recent call last):
  File "/home/jovyan/lattice-tools/scripts/flattener.py", line 1406, in <module>
    main(args.file, connection, args.hcatier1)
  File "/home/jovyan/lattice-tools/scripts/flattener.py", line 1000, in main
    fm.gather_pooled_metadata(obj_type, fm.CELL_METADATA[obj_type], values_to_add, objs, glob.connection)
  File "/home/jovyan/lattice-tools/scripts/flattener_mods/gather.py", line 443, in gather_pooled_metadata
    v = db_ids
        ^^^^^^
UnboundLocalError: cannot access local variable 'db_ids' where it is not associated with a value`

This is a bug caused by incorrect indentation in gather_pooled_metadata. db_ids was being assigned without being instantiated. With this fix, db_ids will only be assigned as the value if dbxrefs is not 'unknown'.