### PR TITLE
return empty list when a report has 0 results

### DIFF
--- a/scripts/lattice.py
+++ b/scripts/lattice.py
@@ -57,8 +57,11 @@ def get_report(obj_type, filter_url, field_lst, connection):
 			obj = requests.get(url, auth=connection.auth)
 			obj.raise_for_status()
 		except requests.exceptions.HTTPError as err:
-			print("HTTP Error: ", err)
-			sys.exit()
+			if obj.status_code == 404 and '@graph' in obj.json():
+				graph.extend(obj.json()['@graph'])
+			else:
+				print("HTTP Error: ", err)
+				sys.exit()
 		except requests.exceptions.Timeout as err:
 			print ("Timeout Error: ",err)
 			sys.exit()


### PR DESCRIPTION
LatticeDB queries that have 0 results return a 404, which errs out currently. This patch exempts this special case and instead returns an empty list