### PR TITLE
Add making var unique after setting raw matrix var indices to gene_ids

### DIFF
--- a/scripts/flattener.py
+++ b/scripts/flattener.py
@@ -1120,6 +1120,9 @@ def main(mfinal_id, connection, hcatier1):
 				adata_raw.obs['raw_matrix_accession'] = mxr['@id']
 				adata_raw.var['gene_symbols'] = adata_raw.var.index
 				adata_raw.var = adata_raw.var.set_index("gene_ids", drop=True)
+				# In case theres duplicate gene_ids, make var index unique
+				adata_raw.var.index = adata_raw.var.index.astype(str)
+				adata_raw.var_names_make_unique(join='.')
 				cxg_adata_lst.append(adata_raw)
        
 		df = pd.concat([df, row_to_add])


### PR DESCRIPTION
The flattener makes var index unique and then later on sets the var indexes of the raw matrices to 'gene_ids' before adding them to a list to be concatenated. If/when 'gene_ids' contains duplicates, this results in an indexing error when concatenating the list. 

This issue was discovered while flattening ProcessedMatrixFile LATDF428BXK.

Solution is to add call to var_names_make_unique after assigning gene_ids to the index.

Tested on LATDF428BXK, and datasets in test_flattener.py