### PR TITLE
Update concurrent validation

### DIFF
--- a/scripts/concurrent_validation.py
+++ b/scripts/concurrent_validation.py
@@ -85,7 +85,7 @@ def make_file_list(args: argparse.Namespace) -> list[Path]:
             f 
             for f in args.directory.iterdir()
             if any(
-                test_file in f 
+                test_file in f.name 
                 for test_file in test_files
             ) 
             and f.name.endswith(file_suffix)

--- a/scripts/concurrent_validation.py
+++ b/scripts/concurrent_validation.py
@@ -76,7 +76,7 @@ def make_file_list(args: argparse.Namespace) -> list[Path]:
     file_suffix = "_revised.h5ad" if args.revised else ".h5ad"
 
     if args.testfile:
-        testfile_path = Path(DIR) / args.testfile
+        testfile_path = Path(args.directory) / args.testfile
         assert testfile_path.suffix == ".txt", "Test file needs to be txt file"
         with open(testfile_path, "r") as f:
             test_files = [line.partition("#")[0].strip() for line in f if not line.startswith("#")]

--- a/scripts/concurrent_validation.py
+++ b/scripts/concurrent_validation.py
@@ -5,6 +5,7 @@ import logging.handlers
 import multiprocessing
 import os
 import subprocess
+import sys
 import threading
 from datetime import datetime
 from multiprocessing import Queue
@@ -236,6 +237,7 @@ if __name__ == "__main__":
     # set up concurrent validation logger and first log messages
     logger = logging.getLogger("concurrent_validation")
     logger.debug("Logger thread started")
+    logger.debug(f"Command line args: {' '.join(sys.argv)}")
 
     revised_str = " REVISED" if ARGS.revised else ""
     logger.info(f"\nFound {len(files)}{revised_str} h5ad(s) in {ARGS.directory} to validate")

--- a/scripts/concurrent_validation.py
+++ b/scripts/concurrent_validation.py
@@ -28,12 +28,14 @@ Use argument -r --revised to only collect h5ad files with the '_revised.h5ad' su
 Use argument -t --testfile to select h5ads from a test_flattener input txt file
 Use argument -pa --pre-analysis to run pre-analysis validation
 Use arugment -i --ignore-labels to ignore ontological labels when validating
+Use arugment -lo --log-output to log validation output to file
 
 Examples:
     python {SCRIPT_NAME} -d /mnt/test_files -r
     python {SCRIPT_NAME} --revised --directory /Users/me/Documents/curation/files
     python {SCRIPT_NAME} --testfile test_processed_matrix_files.txt
     python {SCRIPT_NAME} --directory /home/shared/home/curated_matrices --pre-analysis --ignore-labels
+    python {SCRIPT_NAME} --directory /home/shared/home/curated_matrices -pa -i --log-output
 """
 
 def getArgs() -> argparse.Namespace:

--- a/scripts/concurrent_validation.py
+++ b/scripts/concurrent_validation.py
@@ -89,7 +89,7 @@ def getArgs() -> argparse.Namespace:
     return args
 
 
-def logger_thread(queue: Queue):
+def logger_thread(queue: Queue) -> None:
     """
     Cleaned up logger thread that does not use manager (like in fragment curator)
     No exception handling, but seems to work for now
@@ -102,7 +102,7 @@ def logger_thread(queue: Queue):
         logger.handle(record)
 
 
-def create_logger(queue: Queue):
+def create_logger(queue: Queue) -> None:
     """
     Function to create logger in process workers
     For stream and file handling, best to set root logger in process
@@ -119,7 +119,7 @@ def create_logger(queue: Queue):
     root.propagate = False
 
 
-def worker_init(queue: Queue):
+def worker_init(queue: Queue) -> None:
     """
     Init function to get logging queue to individual process workers.
     Different from fragment curator where manager is used

--- a/scripts/concurrent_validation.py
+++ b/scripts/concurrent_validation.py
@@ -43,7 +43,7 @@ def getArgs() -> argparse.Namespace:
     parser.add_argument(
         "--testfile", 
         "-t",
-        help="Filter h5ads based on flattener testing input file",
+        help="Filter h5ads based on flattener testing input file. Test file should be in same directory as h5ads",
         default="",
     )
     parser.add_argument(

--- a/scripts/concurrent_validation.py
+++ b/scripts/concurrent_validation.py
@@ -8,7 +8,7 @@ from pathlib import Path
 CPU_COUNT = os.cpu_count()
 FILE = Path(__file__).resolve()
 DIR = FILE.parent
-SCRIPT_NAME = FILE.name 
+SCRIPT_NAME = FILE.name
 PRINT_WIDTH = 113
 
 EPILOG = f"""
@@ -53,7 +53,7 @@ def getArgs() -> argparse.Namespace:
         action="store_true",
     )
     parser.add_argument(
-        "--ignore-labels", 
+        "--ignore-labels",
         "-i",
         help="Ignore ontology labels when validating",
         action="store_const",
@@ -61,7 +61,7 @@ def getArgs() -> argparse.Namespace:
         default="",
     )
     parser.add_argument(
-        "--pre-analysis", 
+        "--pre-analysis",
         "-pa",
         help="Include pre-analysis validation requirements in validating the data",
         action="store_const",
@@ -83,12 +83,12 @@ def make_file_list(args: argparse.Namespace) -> list[Path]:
 
         tested_h5ads = [
             f 
-            for f in args.directory.iterdir() 
+            for f in args.directory.iterdir()
             if any(
                 test_file in f 
                 for test_file in test_files
             ) 
-            and f.name.endswith(file_suffix) 
+            and f.name.endswith(file_suffix)
         ]
 
         return tested_h5ads

--- a/scripts/concurrent_validation.py
+++ b/scripts/concurrent_validation.py
@@ -234,7 +234,6 @@ if __name__ == "__main__":
     # set up concurrent validation logger and first log messages
     logger = logging.getLogger("concurrent_validation")
     logger.debug("Logger thread started")
-    logger.debug(logging_config)
 
     revised_str = " REVISED" if ARGS.revised else ""
     logger.info(f"\nFound {len(files)}{revised_str} h5ad(s) in {ARGS.directory} to validate")

--- a/scripts/concurrent_validation.py
+++ b/scripts/concurrent_validation.py
@@ -24,7 +24,7 @@ Examples:
     python {SCRIPT_NAME} --testfile test_processed_matrix_files.txt
 """
 
-def getArgs():
+def getArgs() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description=__doc__, 
         epilog=EPILOG,
@@ -53,7 +53,7 @@ def getArgs():
     return args
 
 
-def make_file_list(args):
+def make_file_list(args: argparse.Namespace) -> list[Path]:
     file_suffix = "_revised.h5ad" if args.revised else ".h5ad"
 
     if args.testfile:
@@ -82,7 +82,7 @@ ARGS = getArgs()
 files = make_file_list(ARGS)
 workers = min(len(files), CPU_COUNT)
 
-def validate(file_name):
+def validate(file_name: Path | str) -> None:
     full_path = ARGS.directory / file_name
     validate = subprocess.run(
         ["cellxgene-schema", "validate", full_path],
@@ -97,7 +97,7 @@ def validate(file_name):
     print("=" * PRINT_WIDTH + "\n")
 
 
-def validate_all_files(files):
+def validate_all_files(files: list[Path]) -> None:
     with multiprocessing.Pool(processes=workers) as pool:
         pool.map(validate, files)
 

--- a/scripts/concurrent_validation.py
+++ b/scripts/concurrent_validation.py
@@ -6,7 +6,6 @@ import multiprocessing
 import os
 import subprocess
 import sys
-import threading
 from datetime import datetime
 from multiprocessing import Queue
 from pathlib import Path
@@ -18,8 +17,8 @@ FILE = Path(__file__).resolve()
 DIR = FILE.parent
 LOG_QUEUE = None
 SCRIPT_NAME = FILE.name
-STOP_SIGNAL = None
 PRINT_WIDTH = 113
+TERMINAL_ERROR_LIMIT = 100
 
 EPILOG = f"""
 Script to run CXG validation in parallel.
@@ -90,19 +89,6 @@ def getArgs() -> argparse.Namespace:
     return args
 
 
-def logger_thread(queue: Queue) -> None:
-    """
-    Cleaned up logger thread that does not use manager (like in fragment curator)
-    No exception handling, but seems to work for now
-    """
-    while True:
-        record = queue.get()
-        if record is STOP_SIGNAL:
-            break
-        logger = logging.getLogger(record.name)
-        logger.handle(record)
-
-
 def create_logger(queue: Queue) -> None:
     """
     Function to create logger in process workers
@@ -158,7 +144,7 @@ def make_file_list(args: argparse.Namespace) -> list[Path]:
         return files
 
 
-def validate(file_name: Path) -> None:
+def validate(file_name: Path) -> subprocess.CompletedProcess | None:
     """
     Worker function to validate with CXG validator
     Supports pass-through pre-analysis and ignore labels flags
@@ -172,21 +158,28 @@ def validate(file_name: Path) -> None:
             command.append(arg)
     command.append(full_path)
 
-    validate = subprocess.run(
-        command,
-        capture_output=True,
-        text=True,
-    )
-    logging.info(f"Validation for {file_name}...")
-    for line in validate.stdout.splitlines():
-        logging.info(line)
-    for line in validate.stderr.splitlines():
-        logging.info(line)
+    try:
+        validate = subprocess.run(
+            command,
+            capture_output=True,
+            text=True,
+        )
+    except subprocess.CalledProcessError as e:
+        logging.exception(f"Error with subprocess: {e}")
+    except Exception as e:
+        logging.exception(f"Exception occurred: {e}")
+
+    if validate:
+        logging.info(f"Validation for {file_name}...")
+        validation_status = validate.stderr.splitlines()[-1]
+        logging.info(validation_status)
 
     logging.info("=" * PRINT_WIDTH + "\n")
 
+    return validate
 
-def validate_all_files(files: list[Path]) -> None:
+
+def validate_all_files(files: list[Path]) -> list[subprocess.CompletedProcess]:
     """
     Function to create worker pool.
     Uses init function to allow workers access to logging queue
@@ -196,7 +189,9 @@ def validate_all_files(files: list[Path]) -> None:
         initializer=worker_init,
         initargs=(logging_queue,),
     ) as pool:
-        pool.map(validate, files)
+        results = pool.map(validate, files)
+
+    return results
 
 
 # need in global namespace for process workers to access values
@@ -206,7 +201,7 @@ ARGS = getArgs()
 if __name__ == "__main__":
     files = make_file_list(ARGS)
     workers = min(len(files), CPU_COUNT)
-    logging_queue = Queue()
+    logging_queue = Queue(maxsize=-1)
 
     # resuing fragment curator logger with some changes for here
     with open(DIR / "fragment_curator_mods" / "log_config_fragment_curator.yaml", "rt") as f:
@@ -227,28 +222,44 @@ if __name__ == "__main__":
     }
     logging.config.dictConfig(logging_config)
 
-    listener = threading.Thread(
-        target=logger_thread, 
-        args=(logging_queue,),
-        daemon=True,
-    )
-    listener.start()
-
     # set up concurrent validation logger and first log messages
     logger = logging.getLogger("concurrent_validation")
+    listener = logging.handlers.QueueListener(logging_queue, *logger.handlers, respect_handler_level=True)
+    listener.start()
     logger.debug("Logger thread started")
     logger.debug(f"Command line args: {' '.join(sys.argv)}")
 
     revised_str = " REVISED" if ARGS.revised else ""
     logger.info(f"\nFound {len(files)}{revised_str} h5ad(s) in {ARGS.directory} to validate")
     logger.info("=" * PRINT_WIDTH + "\n")
+    logger.info("===== Summary Validation Results =====\n")
 
-    validate_all_files(files)
+    results = validate_all_files(files)
+
+    logger.info("===== Final Validation Results =====\n")
+    over_error_limit = False
+    for completed in results:
+        # file will be last arg in args list, preserved as Path, so get name attribute
+        file_name = completed.args[-1].name
+        errors = completed.stderr.splitlines()
+        num_errors = len(errors)
+        logger.info(f"Validation for {file_name}...")
+        for error in errors[:TERMINAL_ERROR_LIMIT]:
+            print(error)
+        if num_errors > TERMINAL_ERROR_LIMIT:
+            over_error_limit = True
+            print("...")
+            print(f"{num_errors} total validation errors")
+            print(f"Full error log available in log file '{log_file_name}'")
+        for error in errors:
+            logger.debug(error)
+
+        logger.info("=" * PRINT_WIDTH + "\n")
 
     logger.debug("Logger thread shutdown")
-    logging_queue.put(STOP_SIGNAL)
-    listener.join()
+    listener.stop()
 
     # just remove log file at end if unwanted, instead of complicated logging config modification
-    if not ARGS.log_output:
+    delete_log = (not ARGS.log_output) and (not over_error_limit)
+    if delete_log:
         Path(log_file_name).unlink()


### PR DESCRIPTION
See TOOLS-282 for more details.

Updating `concurrent_validation.py` to be able to take CXG validation pre-analysis arguments, and to log validation output to file. Both these features should be very helpful for validating the numerous BCP curated matrices.

Tested locally and on JupyterHub with various h5ads within BCP and from other sources (CXG curation, flattener, etc).

