### PR TITLE
enhance mapping validation for provider-specific formats

### DIFF
--- a/bcp/MAPPING_VALIDATION.md
+++ b/bcp/MAPPING_VALIDATION.md
@@ -12,6 +12,16 @@ The validator is implemented in `mapping_validation.cli.main` and is exercised e
   - **Format**: text file with **two columns per non‑empty line**:
     - column 1: S3 path
     - column 2: local filesystem path
+  - **Provider-specific column order**:
+    - Novogene exports are typically `S3 path,local path`.
+    - Psomagen exports are sometimes `Local path,S3 path` and may include a header row
+      like `Local Path,S3 Path`.
+    - The parser uses `--provider` as a hint, and falls back to heuristics based on
+      which column starts with `s3://`.
+  - **Ignored lines**:
+    - empty lines
+    - header/meta rows starting with `@` (e.g. `@NVUS...mapping_processed.csv`)
+    - header rows like `Local Path,S3 Path` / `S3 Path,Local Path`
   - **Separators supported**:
     - comma: `s3://...,/ORPROJ1/...`
     - tab: `s3://...\t/ORPROJ1/...`

--- a/bcp/mapping_validation/cli.py
+++ b/bcp/mapping_validation/cli.py
@@ -171,7 +171,7 @@ def main() -> None:
 
     args = parser.parse_args()
 
-    mappings = parse_mapping_file(args.mapping)
+    mappings = parse_mapping_file(args.mapping, provider=args.provider)
     if not mappings:
         print(
             "No mappings parsed from file (check delimiter and content).",

--- a/bcp/mapping_validation/parsing.py
+++ b/bcp/mapping_validation/parsing.py
@@ -14,9 +14,38 @@ class MappingRow:
     line_num: int
 
 
+def _looks_like_s3(s: str) -> bool:
+    return s.startswith("s3://")
+
+
+def _should_skip_line(stripped: str) -> bool:
+    """Heuristics for mapping-file header/meta lines.
+
+    In practice, exported mapping files sometimes include:
+    - header rows: `Local Path,S3 Path` or `S3 Path,Local Path`
+    - metadata rows starting with `@` (e.g. `@NVUS...mapping_processed.csv`)
+    - comments/notes starting with `#`
+    """
+
+    if stripped.startswith("#") or stripped.startswith("@"):
+        return True
+
+    lower = stripped.lower()
+    # Common header variants
+    if lower.startswith("local path") and "s3 path" in lower:
+        return True
+    if lower.startswith("s3 path") and "local path" in lower:
+        return True
+
+    return False
+
+
 def _split_mapping_line(line: str) -> Tuple[str, str] | None:
     """
-    Split a raw line from a mapping file into (s3_path, local_path).
+    Split a raw mapping line into (token1, token2).
+
+    The caller will decide which token is S3 vs local (depending on
+    provider or heuristics).
 
     Supports the common formats in existing mapping files:
     - Comma-separated:  s3://...,/ORPROJ1/...
@@ -26,11 +55,13 @@ def _split_mapping_line(line: str) -> Tuple[str, str] | None:
     stripped = line.strip()
     if not stripped:
         return None
+    if _should_skip_line(stripped):
+        return None
 
     # Preferred: CSV-style with a single comma separating S3 and local
     if "," in stripped:
-        s3, local = stripped.split(",", 1)
-        return s3.strip(), local.strip()
+        col1, col2 = stripped.split(",", 1)
+        return col1.strip(), col2.strip()
 
     # TSV-style
     if "\t" in stripped:
@@ -55,15 +86,25 @@ def _split_mapping_line(line: str) -> Tuple[str, str] | None:
     return None
 
 
-def parse_mapping_file(path: str | Path) -> List[MappingRow]:
+def parse_mapping_file(
+    path: str | Path, provider: str | None = None
+) -> List[MappingRow]:
     """
     Parse a mapping file into a list of MappingRow objects.
 
     Each non-empty line is expected to contain exactly two columns:
-    an S3 path and a local filesystem path. Lines that cannot be
-    parsed into two columns are skipped, but their line numbers are
-    preserved for diagnostics in downstream validators.
+    two path-like fields (one S3, one local). Lines that cannot be
+    parsed into two non-empty fields are skipped, but their line numbers
+    are preserved for diagnostics in downstream validators.
+
+    Provider-dependent exports:
+    - `psomagen` exports are sometimes `Local Path,S3 Path`
+    - `novogene` exports are sometimes `S3 Path,Local Path`
+
+    We use `provider` as a hint, but fall back to heuristics based on
+    which token looks like an `s3://...` URL.
     """
+    provider = provider.lower() if provider else None
     rows: List[MappingRow] = []
     p = Path(path)
     with p.open("r", encoding="utf-8") as fh:
@@ -71,9 +112,30 @@ def parse_mapping_file(path: str | Path) -> List[MappingRow]:
             parts = _split_mapping_line(raw)
             if parts is None:
                 continue
-            s3, local = parts
-            if not s3 or not local:
+
+            tok1, tok2 = parts
+            if not tok1 or not tok2:
                 continue
+
+            # Choose which token is S3. Provider is a hint, not a guarantee.
+            if provider == "novogene":
+                expected_s3_idx = 0
+            elif provider == "psomagen":
+                expected_s3_idx = 1
+            else:
+                expected_s3_idx = 0
+
+            expected_s3 = tok1 if expected_s3_idx == 0 else tok2
+            other = tok2 if expected_s3_idx == 0 else tok1
+
+            if _looks_like_s3(expected_s3):
+                s3, local = expected_s3, other
+            elif _looks_like_s3(other):
+                s3, local = other, expected_s3
+            else:
+                # Neither token looks like an S3 URL. Skip this line.
+                continue
+
             rows.append(MappingRow(s3_path=s3, local_path=local, line_num=line_num))
     return rows
 

--- a/bcp/tests/fixtures/mapping_validation/mappings/psomagen_10x_processed_valid.csv
+++ b/bcp/tests/fixtures/mapping_validation/mappings/psomagen_10x_processed_valid.csv
@@ -1,0 +1,4 @@
+Local Path,S3 Path
+/data/process/CD4i_R1L01/outs/filtered_feature_bc_matrix.h5,s3://czi-psomagen/weissman-perturb/AN00012345/CD4i_R1L01/processed/cellranger/Run_2025-02-01/outs/filtered_feature_bc_matrix.h5
+/data/process/CD4i_R1L01/outs/metrics_summary.csv,s3://czi-psomagen/weissman-perturb/AN00012345/CD4i_R1L01/processed/cellranger/Run_2025-02-01/outs/metrics_summary.csv
+

--- a/bcp/tests/fixtures/mapping_validation/sif/psomagen_10x_processed_sif.csv
+++ b/bcp/tests/fixtures/mapping_validation/sif/psomagen_10x_processed_sif.csv
@@ -1,0 +1,3 @@
+Library name,Group Identifier,Assay Type
+LIB1,CD4i_R1L01,GEX
+

--- a/bcp/tests/test_mapping_validation.py
+++ b/bcp/tests/test_mapping_validation.py
@@ -78,6 +78,35 @@ def test_parse_mapping_file_ignores_malformed_lines(tmp_path: Path) -> None:
     ]
 
 
+def test_parse_mapping_file_psomagen_local_first_header(tmp_path: Path) -> None:
+    """psomagen exports may use `Local Path,S3 Path` column order."""
+    mapping_text = (
+        "Local Path,S3 Path\n"
+        "/local/path/file.h5,s3://czi-psomagen/proj/order/AN00012345/processed/file.h5\n"
+    )
+    path = _write_temp_mapping(tmp_path, mapping_text)
+
+    rows = parse_mapping_file(path, provider="psomagen")
+
+    assert len(rows) == 1
+    assert rows[0].local_path == "/local/path/file.h5"
+    assert rows[0].s3_path.startswith("s3://czi-psomagen/")
+
+
+def test_parse_mapping_file_skips_at_metadata_lines(tmp_path: Path) -> None:
+    """Mapping exports may include `@...` metadata lines that are not rows."""
+    mapping_text = (
+        "@NVUS2024101701-19-mapping_processed.csv (1-3)\ns3://bucket/a,/local/a\n"
+    )
+    path = _write_temp_mapping(tmp_path, mapping_text)
+
+    rows = parse_mapping_file(path, provider="novogene")
+
+    assert len(rows) == 1
+    assert rows[0].s3_path == "s3://bucket/a"
+    assert rows[0].local_path == "/local/a"
+
+
 def test_validate_uniqueness_detects_duplicate_local_and_s3() -> None:
     """validate_uniqueness should flag many-to-one and one-to-many mappings."""
     rows = [

--- a/bcp/tests/test_mapping_validation_e2e.py
+++ b/bcp/tests/test_mapping_validation_e2e.py
@@ -56,6 +56,14 @@ FIXTURES_DIR = Path(__file__).parent / "fixtures" / "mapping_validation"
             "10x",
             0,
         ),
+        (
+            "psomagen_10x_processed_valid.csv",
+            "psomagen_10x_processed_sif.csv",
+            "psomagen",
+            "processed",
+            "10x",
+            0,
+        ),
         # Error paths
         ("duplicates.csv", None, "novogene", "raw", "10x", 1),
         (


### PR DESCRIPTION
- Updated the mapping validation logic to handle provider-specific column orders for Novogene and Psomagen exports.
- Added heuristics to skip header and metadata lines in mapping files.
- Enhanced the `parse_mapping_file` function to accept a provider argument, improving flexibility in parsing.
- Introduced new tests to validate the handling of Psomagen exports and metadata lines.

This update improves the robustness of the mapping validation process and ensures compatibility with varying export formats.