### PR TITLE
fix: enhance local path validation for v2 lane variants

### DIFF
--- a/bcp/mapping_validation/validators.py
+++ b/bcp/mapping_validation/validators.py
@@ -564,9 +564,9 @@ def validate_local_paths_scale_raw(mappings: Iterable[MappingRow]) -> dict:
     v2_pattern = re.compile(
         r"(?P<base_path>.+)/"
         r"(?P<wafer>\d+)-(?P<date>\d+_\d+)/"
-        r"(?P<dir_stem>(?P<wafer2>\d+)-QSR(?P<qsr_compact>\d+)(?P<sp_compact>SCALEPLEX)?"
+        r"(?P<dir_stem>(?P<wafer2>\d+)(?:_(?P<lane2>\d+))?-QSR(?P<qsr_compact>\d+)(?P<sp_compact>SCALEPLEX)?"
         r"_QSR-(?P<qsr_dash>\d+)(?P<sp_dash>-SCALEPLEX)?)/"
-        r"(?P<file_stem>(?P<wafer3>\d+)-QSR(?P<qsr_compact2>\d+)(?P<sp_compact2>SCALEPLEX)?"
+        r"(?P<file_stem>(?P<wafer3>\d+)(?:_(?P<lane3>\d+))?-QSR(?P<qsr_compact2>\d+)(?P<sp_compact2>SCALEPLEX)?"
         r"_QSR-(?P<qsr_dash2>\d+)(?P<sp_dash2>-SCALEPLEX)?)"
         r"_(?P<wellcode>[A-Za-z0-9]+)"
         r"(?P<suffix>.*)"
@@ -665,14 +665,24 @@ def validate_local_paths_scale_raw(mappings: Iterable[MappingRow]) -> dict:
                     }
                 )
 
-            if gd["dir_stem"] != gd["file_stem"]:
+            # Compare parsed, stable components rather than requiring the
+            # directory stem string to equal the filename prefix string.
+            # In particular, some datasets include an additional `_\<lane\>_`
+            # element between wafer digits and `-QSR`.
+            if (
+                gd["qsr_compact"] != gd["qsr_compact2"]
+                or gd["qsr_dash"] != gd["qsr_dash2"]
+            ):
                 errors.append(
                     {
-                        "type": "dir_file_mismatch",
+                        "type": "qsr_mismatch",
                         "line": row.line_num,
                         "local_path": local,
-                        "detail": f"directory name '{gd['dir_stem']}' does not match "
-                        f"filename prefix '{gd['file_stem']}'",
+                        "detail": (
+                            "QSR numbers mismatch between directory and filename: "
+                            f"compact QSR{gd['qsr_compact']} vs QSR{gd['qsr_compact2']}; "
+                            f"dashed QSR-{gd['qsr_dash']} vs QSR-{gd['qsr_dash2']}"
+                        ),
                     }
                 )
 
@@ -683,6 +693,25 @@ def validate_local_paths_scale_raw(mappings: Iterable[MappingRow]) -> dict:
                         "line": row.line_num,
                         "local_path": local,
                         "detail": "SCALEPLEX present in one part of the directory name but not the other",
+                    }
+                )
+            if bool(gd["sp_compact2"]) != bool(gd["sp_dash2"]):
+                errors.append(
+                    {
+                        "type": "scaleplex_mismatch",
+                        "line": row.line_num,
+                        "local_path": local,
+                        "detail": "SCALEPLEX present in one part of the filename but not the other",
+                    }
+                )
+
+            if bool(gd["sp_compact"]) != bool(gd["sp_compact2"]):
+                errors.append(
+                    {
+                        "type": "scaleplex_mismatch",
+                        "line": row.line_num,
+                        "local_path": local,
+                        "detail": "SCALEPLEX presence differs between directory and filename",
                     }
                 )
 

--- a/bcp/tests/test_mapping_validation.py
+++ b/bcp/tests/test_mapping_validation.py
@@ -240,6 +240,59 @@ def test_validate_local_paths_scale_raw_detects_qsr_mismatch() -> None:
     assert "qsr_mismatch" in error_types
 
 
+def test_validate_local_paths_scale_raw_accepts_v2_lane_variant() -> None:
+    """Local v2 paths may include `_lane` between wafer digits and `-QSR`."""
+    row = MappingRow(
+        s3_path="s3://example-bucket/some/prefix",
+        local_path=(
+            "/ORPROJ1/DATA1/V129/440115-20260319_2239/"
+            "440115_1-QSR8_QSR-8/440115_1-QSR8_QSR-8_7A.csv"
+        ),
+        line_num=1,
+    )
+
+    result = validate_local_paths_scale_raw([row])
+
+    assert result["matched"] == 1
+    assert result["errors"] == []
+
+
+def test_validate_local_paths_scale_raw_v2_lane_variant_detects_qsr_mismatch() -> None:
+    """QSR numbers between directory and filename must match."""
+    row = MappingRow(
+        s3_path="s3://example-bucket/some/prefix",
+        local_path=(
+            "/ORPROJ1/DATA1/V129/440115-20260319_2239/"
+            "440115_1-QSR8_QSR-8/440115_1-QSR9_QSR-9_7A.csv"
+        ),
+        line_num=2,
+    )
+
+    result = validate_local_paths_scale_raw([row])
+
+    assert result["matched"] == 1
+    error_types = {e["type"] for e in result["errors"]}
+    assert "qsr_mismatch" in error_types
+
+
+def test_validate_local_paths_scale_raw_accepts_v2_lane_variant_scaleplex() -> None:
+    """Lane variant should also work for SCALEPLEX compact/dashed forms."""
+    row = MappingRow(
+        s3_path="s3://example-bucket/some/prefix",
+        local_path=(
+            "/ORPROJ1/DATA1/V129/440115-20260319_2239/"
+            "440115_1-QSR8SCALEPLEX_QSR-8-SCALEPLEX/"
+            "440115_1-QSR8SCALEPLEX_QSR-8-SCALEPLEX_12G.json"
+        ),
+        line_num=3,
+    )
+
+    result = validate_local_paths_scale_raw([row])
+
+    assert result["matched"] == 1
+    assert result["errors"] == []
+
+
 def test_validate_s3_scale_raw_flags_hash_oliga_typo() -> None:
     """S3 Scale raw paths with 'Hash_oliga' should be treated as invalid assay.
 
@@ -407,7 +460,7 @@ def test_validate_local_paths_scale_raw_v2_detects_dir_file_mismatch() -> None:
 
     assert result["matched"] == 1
     error_types = {e["type"] for e in result["errors"]}
-    assert "dir_file_mismatch" in error_types
+    assert "qsr_mismatch" in error_types
 
 
 # --- Assay-anchored regex tests ---


### PR DESCRIPTION
- Updated the regex patterns in `validate_local_paths_scale_raw` to accommodate optional lane identifiers in local paths.
- Improved error handling for QSR number mismatches and SCALEPLEX presence discrepancies between directory and filename.
- Added new tests to validate the handling of lane variants and ensure correct error reporting for mismatches.

This update enhances the robustness of the mapping validation process for v2 paths.