### PR TITLE
Tools 313 finalizing main df

### DIFF
--- a/TOOLS-285-DB2Flattener/DB2Flattener.py
+++ b/TOOLS-285-DB2Flattener/DB2Flattener.py
@@ -210,7 +210,7 @@ class DB2Flattener:
         return main_df, new_sample_df
 
     def _row_is_gex(self, row) -> bool:
-        """ Filter MAIN df to only GEX libraries"""
+        """ Filter df to only GEX libraries"""
         droplet_ft = row.get('droplet_based_libraries_feature_types')
         plate_ft = row.get('plate_based_libraries_feature_types')
 

--- a/TOOLS-285-DB2Flattener/DB2Flattener.py
+++ b/TOOLS-285-DB2Flattener/DB2Flattener.py
@@ -4,7 +4,13 @@ import pandas as pd
 from datetime import datetime
 from DB2Gatherer import DB2Gatherer
 from constants import Configs, PROP_MAP_GEO
-from df_utils import split_controlled_term_columns, collapse_dataframe
+from DB2_utils import (
+    split_controlled_term_columns, 
+    collapse_dataframe,
+    get_config_obj_type,
+    get_url_prefix_from_id,
+    extract_references_from_field
+)
 from generate_constants import load_and_return_constant_dicts
 import DB2lattice
 
@@ -161,18 +167,6 @@ class DB2Flattener:
                         if sample_alias in sample_metadata:
                             continue
                         
-                        sample_donors = []
-                        sample_donor_refs = sample_obj.get('donors', [])
-                        for donor_ref in sample_donor_refs:
-                            if isinstance(donor_ref, dict):
-                                donor_id = donor_ref.get('@id', '')
-                            else:
-                                donor_id = donor_ref
-                            
-                            donor_obj = next((d for d in lib_data['donors'] if d.get('@id') == donor_id), None)
-                            if donor_obj:
-                                sample_donors.append(donor_obj)
-                        
                         sample_metadata[sample_alias] = {
                             'enriched_cell_types': self._get_cell_types_from_samples(
                                 [sample_obj], 'enriched_cell_types', resolved_controlled_terms
@@ -192,13 +186,9 @@ class DB2Flattener:
                             value = sample_obj.get(field)
                             sample_metadata[sample_alias][field_name] = value
 
-                        for d in sample_donors:
-                            donor_type = get_config_obj_type(d, self.configs)
-                            for field in self.configs.OBJECT_CONFIG[donor_type].get('fields', []):
-                                field_name = f'{donor_type}_{field}'
-                                value = d.get(field)
-                                sample_metadata[sample_alias][field_name] = value
-
+                        self._flatten_resolved_references(
+                            sample_obj, lib_data, sample_metadata, sample_alias
+                        )
 
         
         # Create one row per raw matrix file for main DataFrame
@@ -272,6 +262,45 @@ class DB2Flattener:
 
         group_col = "*library name"
         return collapse_dataframe(geo_df, group_col=group_col)
+
+    def _flatten_resolved_references(self, sample_obj, lib_data, sample_metadata, sample_alias):
+        """Flatten resolved reference objects into sample_metadata columns."""
+        sample_type = get_config_obj_type(sample_obj, self.configs)
+        config = self.configs.OBJECT_CONFIG.get(sample_type, {})
+        # Group refs by URL prefix across all non-controlled-term fields
+        refs_by_prefix = {}
+        for field_name, ref_types in config.get('references', {}).items():
+            ref_type_list = [ref_types] if isinstance(ref_types, str) else ref_types
+            if 'controlled_terms' in ref_type_list:
+                continue
+
+            refs = extract_references_from_field(
+                sample_obj.get(field_name), field_name, self.configs
+            )
+            for ref in refs:
+                prefix = get_url_prefix_from_id(ref, self.configs)
+                if prefix:
+                    refs_by_prefix.setdefault(prefix, []).append(ref)
+
+        for url_prefix, refs in refs_by_prefix.items():
+            seen = set()
+            unique_refs = [r for r in refs if not (r in seen or seen.add(r))]
+
+            resolved_objs = [
+                obj for ref in unique_refs
+                for obj in lib_data.get(url_prefix, [])
+                if obj.get('@id') == ref
+            ]
+
+            for obj_field in self.configs.OBJECT_CONFIG.get(url_prefix, {}).get('fields', []):
+                col = f'{url_prefix}_{obj_field}'
+                values = [
+                    obj.get(obj_field) for obj in resolved_objs
+                    if obj.get(obj_field) is not None
+                ]
+                sample_metadata[sample_alias][col] = (
+                    self._join_unique(values) if values else None
+                )
 
     def _resolve_controlled_term(self, term_ref, resolved_controlled_terms):
         """Resolve a controlled term reference to its term_id (semantic identifier)"""
@@ -360,12 +389,6 @@ class DB2Flattener:
             return result.split(':', 1)[1]  # Take everything after the first ':'
         return result
 
-def get_config_obj_type(obj, configs: Configs):
-    """ Returns the matching object type for an object as found in the config file"""
-    for config_obj_type, config_obj_info in configs.OBJECT_CONFIG.items():
-        if config_obj_info.get('api_type','') == obj.get('@type',[])[0]:
-            return config_obj_type
-    return ''
 
 def main():
     parser = argparse.ArgumentParser(

--- a/TOOLS-285-DB2Flattener/DB2Flattener.py
+++ b/TOOLS-285-DB2Flattener/DB2Flattener.py
@@ -115,8 +115,10 @@ class DB2Flattener:
                         'all_samples': []
                     }
                 
-                # Add this library's data to the raw matrix file
-                raw_file_to_libraries[raw_file_id]['libraries'].append(library)
+                # Add this library's data to the raw matrix file (once per @id to prevent duplicates due to having GEX and CRI)
+                existing_lib_ids = {lib.get('@id') for lib in raw_file_to_libraries[raw_file_id]['libraries']}
+                if library.get('@id') not in existing_lib_ids:
+                    raw_file_to_libraries[raw_file_id]['libraries'].append(library)
                 raw_file_to_libraries[raw_file_id]['all_samples'].extend(samples)
                 
                 # Collect per-sample metadata for later merge with raw matrix files
@@ -150,51 +152,50 @@ class DB2Flattener:
                             sample_obj, lib_data, sample_metadata, sample_alias, resolved_controlled_terms
                         )
 
-        
-        # Create one row per raw matrix file for main DataFrame
+        # Create one row per (raw matrix file, library)
         for file_data in raw_file_to_libraries.values():
             raw_file = file_data['raw_file']
             libraries = file_data['libraries']
             samples = file_data['all_samples']
-            
-            # Create sample aliases list
+
             sample_aliases = []
             for sample_ref in raw_file.get('samples', []):
                 sample_obj = next((s for s in samples if s.get('@id') == sample_ref), None)
                 if sample_obj:
-                    alias = self._get_clean_alias(sample_obj)
-                    sample_aliases.append(alias)
+                    sample_aliases.append(self._get_clean_alias(sample_obj))
 
-            # Gather all fields for all objects
-            # First determine appropriate object list for each object type
-            row = {
+            shared = {
                 'raw_matrix_file_alias': self._get_clean_alias(raw_file),
-                'raw_file_samples': self._join_unique(sample_aliases)
+                'raw_file_samples': self._join_unique(sample_aliases),
             }
+
             for lib in libraries:
+                row = dict(shared)
                 lib_type = get_config_obj_type(lib, self.configs)
-                for field in self.configs.OBJECT_CONFIG[lib_type].get('fields',[]):
+                for field in self.configs.OBJECT_CONFIG[lib_type].get('fields', []):
                     field_name = f'{lib_type}_{field}'
-                    value = lib.get(field)
-                    row[field_name] = value
-            
-            rows.append(row)
+                    row[field_name] = lib.get(field)
+                rows.append(row)
         
         main_df = pd.DataFrame(rows)
         
-        # Merge sample metadata with all main DataFrame columns, one row per raw matrix file + sample
+        # Merge sample metadata with main DataFrame columns
+        # Samples is one row per unique (raw matrix file + sample)
         sample_df = None
         if sample_metadata and not main_df.empty:
             per_sample_df = pd.DataFrame.from_dict(sample_metadata, orient='index')
             per_sample_df.index.name = 'sample_alias'
             per_sample_df = per_sample_df.reset_index()
+
+            rmf_sample_keys = main_df[['raw_matrix_file_alias','raw_file_samples']].drop_duplicates()
             
             sample_df = per_sample_df.merge(
-                main_df[['raw_matrix_file_alias','raw_file_samples']],
+                rmf_sample_keys,
                 left_on = 'sample_alias',
                 right_on ='raw_file_samples', 
                 how = 'right'
             )
+            
             new_sample_df = sample_df.set_index('raw_matrix_file_alias')
 
             main_df = main_df.merge(

--- a/TOOLS-285-DB2Flattener/DB2Flattener.py
+++ b/TOOLS-285-DB2Flattener/DB2Flattener.py
@@ -83,52 +83,12 @@ class DB2Flattener:
             print(f"   Columns: {len(sample_df.columns)}")
         
         return output_file
-        
-        
-    def _filter_to_gex_libraries(self, libraries):
-        """Filter libraries to only include Gene Expression when there are pairs"""
-        gex_libraries = []
-        
-        for lib in libraries:
-            feature_types = lib.get('feature_types', [])
-            lib_type = lib.get('@type', [''])[0] if lib.get('@type') else ''
-            
-            # Check if this library has Gene Expression
-            if 'Gene Expression' in feature_types:
-                gex_libraries.append(lib)
-            elif not feature_types:  # Empty list or missing field
-                # For droplet-based libraries without feature_types, assume non-GEX
-                if 'DropletBasedLibrary' in lib_type:
-                    continue  # Skip droplet libraries without feature_types
-                # For plate-based libraries without feature_types, assume GEX until field is added
-                elif 'PlateBasedLibrary' in lib_type:
-                    gex_libraries.append(lib)
-        
-        # Always return only GEX libraries
-        if gex_libraries:
-            print(f"Filtered to {len(gex_libraries)} Gene Expression libraries out of {len(libraries)} total")
-            return gex_libraries
-        
-        # Fallback: if no GEX libraries found, return all (shouldn't happen normally)
-        print("WARNING: No Gene Expression libraries found, keeping all libraries")
-        return libraries
     
     
     def create_dataframe(self, complete_data):
         """Create main library/raw-file DataFrame and sample DataFrame keyed by raw matrix file"""
         libraries_data = complete_data['libraries']
         resolved_controlled_terms = complete_data['resolved_objects'].get('ControlledTerm', {})
-    
-        # Filter libraries to GEX once upfront
-        all_libraries = [lib_data['library'] for lib_data in libraries_data.values()]
-        filtered_libraries = self._filter_to_gex_libraries(all_libraries)
-        filtered_library_ids = {lib.get('@id') for lib in filtered_libraries}
-        
-        # Filter libraries_data to only include GEX libraries
-        filtered_libraries_data = {
-            lib_uuid: lib_data for lib_uuid, lib_data in libraries_data.items()
-            if lib_data['library'].get('@id') in filtered_library_ids
-        }
         
         print("Creating DataFrame by raw matrix file...")
         
@@ -141,7 +101,7 @@ class DB2Flattener:
         raw_file_to_libraries = {}
         sample_metadata = {}  # One row per unique sample, keyed by sample_alias
         
-        for lib_data in filtered_libraries_data.values():
+        for lib_data in libraries_data.values():
             library = lib_data['library']
             samples = lib_data['samples']
             raw_matrix_files = lib_data['raw_matrix_files']
@@ -249,15 +209,51 @@ class DB2Flattener:
         
         return main_df, new_sample_df
 
+    def _row_is_gex(self, row) -> bool:
+        """ Filter MAIN df to only GEX libraries"""
+        droplet_ft = row.get('droplet_based_libraries_feature_types')
+        plate_ft = row.get('plate_based_libraries_feature_types')
+
+        def has_gex(ft):
+            if ft is None or (isinstance(ft, float) and pd.isna(ft)):
+                return None  # missing
+            if isinstance(ft, str):
+                return 'Gene Expression' in ft
+            if isinstance(ft, list):
+                return 'Gene Expression' in ft
+            return 'Gene Expression' in str(ft)
+
+        droplet = has_gex(droplet_ft)
+        plate = has_gex(plate_ft)
+
+        if droplet is True or plate is True:
+            return True
+        if droplet is False or plate is False:
+            return False
+
+        # Missing feature_types: plate assumed GEX, droplet assumed non-GEX
+        if pd.notna(row.get('plate_based_libraries_@id')) or pd.notna(
+            row.get('plate_based_libraries_CRO_group_identifier')
+        ):
+            return True
+        if pd.notna(row.get('droplet_based_libraries_@id')) or pd.notna(
+            row.get('droplet_based_libraries_CRO_group_identifier')
+        ):
+            return False
+        return True  # if no GEX found, keep all
+
     def create_geo_dataframe(self, main_df) -> pd.DataFrame:
         """
-        Build GEO submission dataframe from already-split main_df.
+        Build GEO submission dataframe from already-split main_df, taking GEX libraries only
 
         Expects _term_name columns (not raw dict columns).
         """
-        # Only keep columns that exist after split + rename
-        subset_keys = [k for k in PROP_MAP_GEO if k in main_df.columns]
-        geo_df = main_df[subset_keys].copy()
+        gex_mask = main_df.apply(self._row_is_gex, axis=1)
+        geo_source = main_df[gex_mask].copy()
+        print(f"GEO: filtered to {len(geo_source)} GEX rows out of {len(main_df)} MAIN rows")
+
+        subset_keys = [k for k in PROP_MAP_GEO if k in geo_source.columns]
+        geo_df = geo_source[subset_keys].copy()
         geo_df.rename(columns=PROP_MAP_GEO, inplace=True)
 
         group_col = "*library name"
@@ -315,7 +311,7 @@ class DB2Flattener:
                         )
                     if value not in (None, ''):
                         values.append(value)
-                        
+
                 sample_metadata[sample_alias][col] = (
                     self._join_unique(values) if values else None
                 )

--- a/TOOLS-285-DB2Flattener/DB2Flattener.py
+++ b/TOOLS-285-DB2Flattener/DB2Flattener.py
@@ -115,7 +115,7 @@ class DB2Flattener:
                         'all_samples': []
                     }
                 
-                # Add this library's data to the raw matrix file (once per @id to prevent duplicates due to having GEX and CRI)
+                # Add this library's data to the raw matrix file (once per @id to prevent duplicates)
                 existing_lib_ids = {lib.get('@id') for lib in raw_file_to_libraries[raw_file_id]['libraries']}
                 if library.get('@id') not in existing_lib_ids:
                     raw_file_to_libraries[raw_file_id]['libraries'].append(library)
@@ -144,9 +144,15 @@ class DB2Flattener:
 
                         sample_type = get_config_obj_type(sample_obj, self.configs)
                         for field in self.configs.OBJECT_CONFIG[sample_type].get('fields', []):
-                            field_name = f'{sample_type}_{field}'
                             value = sample_obj.get(field)
-                            sample_metadata[sample_alias][field_name] = value
+                            # Special handling for author_metadata dictionary
+                            if field == 'author_metadata' and isinstance(value, dict):
+                                for key, val in value.items():
+                                    field_name = f"{sample_type}_{'_'.join(key.split(' '))}"
+                                    sample_metadata[sample_alias][field_name] = val
+                            else:
+                                field_name = f'{sample_type}_{field}'
+                                sample_metadata[sample_alias][field_name] = value
 
                         self._flatten_resolved_references(
                             sample_obj, lib_data, sample_metadata, sample_alias, resolved_controlled_terms

--- a/TOOLS-285-DB2Flattener/DB2Flattener.py
+++ b/TOOLS-285-DB2Flattener/DB2Flattener.py
@@ -187,7 +187,7 @@ class DB2Flattener:
                             sample_metadata[sample_alias][field_name] = value
 
                         self._flatten_resolved_references(
-                            sample_obj, lib_data, sample_metadata, sample_alias
+                            sample_obj, lib_data, sample_metadata, sample_alias, resolved_controlled_terms
                         )
 
         
@@ -263,11 +263,13 @@ class DB2Flattener:
         group_col = "*library name"
         return collapse_dataframe(geo_df, group_col=group_col)
 
-    def _flatten_resolved_references(self, sample_obj, lib_data, sample_metadata, sample_alias):
+    def _flatten_resolved_references(
+        self, sample_obj, lib_data, sample_metadata, sample_alias, resolved_controlled_terms
+    ):
         """Flatten resolved reference objects into sample_metadata columns."""
         sample_type = get_config_obj_type(sample_obj, self.configs)
         config = self.configs.OBJECT_CONFIG.get(sample_type, {})
-        # Group refs by URL prefix across all non-controlled-term fields
+
         refs_by_prefix = {}
         for field_name, ref_types in config.get('references', {}).items():
             ref_type_list = [ref_types] if isinstance(ref_types, str) else ref_types
@@ -292,12 +294,28 @@ class DB2Flattener:
                 if obj.get('@id') == ref
             ]
 
-            for obj_field in self.configs.OBJECT_CONFIG.get(url_prefix, {}).get('fields', []):
+            obj_config = self.configs.OBJECT_CONFIG.get(url_prefix, {})
+            obj_refs = obj_config.get('references', {})
+
+            for obj_field in obj_config.get('fields', []):
                 col = f'{url_prefix}_{obj_field}'
-                values = [
-                    obj.get(obj_field) for obj in resolved_objs
-                    if obj.get(obj_field) is not None
-                ]
+                field_ref_types = obj_refs.get(obj_field, [])
+                if isinstance(field_ref_types, str):
+                    field_ref_types = [field_ref_types]
+                is_controlled_term = 'controlled_terms' in field_ref_types
+
+                values = []
+                for obj in resolved_objs:
+                    value = obj.get(obj_field)
+                    if value is None:
+                        continue
+                    if is_controlled_term:
+                        value = self._resolve_controlled_term(
+                            value, resolved_controlled_terms
+                        )
+                    if value not in (None, ''):
+                        values.append(value)
+                        
                 sample_metadata[sample_alias][col] = (
                     self._join_unique(values) if values else None
                 )

--- a/TOOLS-285-DB2Flattener/DB2Flattener.py
+++ b/TOOLS-285-DB2Flattener/DB2Flattener.py
@@ -148,7 +148,7 @@ class DB2Flattener:
                             # Special handling for author_metadata dictionary
                             if field == 'author_metadata' and isinstance(value, dict):
                                 for key, val in value.items():
-                                    field_name = f"{sample_type}_{'_'.join(key.split(' '))}"
+                                    field_name = f"{sample_type}_{field}_{'_'.join(key.split(' '))}"
                                     sample_metadata[sample_alias][field_name] = val
                             else:
                                 field_name = f'{sample_type}_{field}'
@@ -319,9 +319,22 @@ class DB2Flattener:
                     if value not in (None, ''):
                         values.append(value)
 
-                sample_metadata[sample_alias][col] = (
-                    self._join_unique(values) if values else None
-                )
+                # Specific handling for author metadata fields
+                if obj_field == 'author_metadata':
+                    values_by_key = {}
+                    for value in values:
+                        if isinstance(value, dict):
+                            for key, val in value.items():
+                                sanitized_key = '_'.join(key.split(' '))
+                                values_by_key.setdefault(sanitized_key, []).append(val)
+                    for key, vals in values_by_key.items():
+                        col = f"{url_prefix}_{obj_field}_{key}"
+                        sample_metadata[sample_alias][col] = self._join_unique(vals)
+                        
+                else:
+                    sample_metadata[sample_alias][col] = (
+                        self._join_unique(values) if values else None
+                    )
 
     def _resolve_controlled_term(self, term_ref, resolved_controlled_terms):
         """Resolve a controlled term reference to its term_id (semantic identifier)"""

--- a/TOOLS-285-DB2Flattener/DB2Gatherer.py
+++ b/TOOLS-285-DB2Flattener/DB2Gatherer.py
@@ -1,4 +1,4 @@
-from constants import Configs, MAX_URL_LENGTH, BASE_URL_OVERHEAD, FETCHED_SAMPLE_REFERENCE_API_TYPES
+from constants import Configs, MAX_URL_LENGTH, BASE_URL_OVERHEAD
 import DB2lattice
 
 
@@ -160,7 +160,7 @@ class DB2Gatherer:
                         else:
                             # Regular UUID-based reference
                             api_type = self.get_api_type_from_id(ref)
-                            if api_type in FETCHED_SAMPLE_REFERENCE_API_TYPES:
+                            if api_type:
                                 all_reference_ids.setdefault(api_type, set()).add(ref)
         
         # Batch fetch all non-controlled-term references by type
@@ -204,8 +204,8 @@ class DB2Gatherer:
                                 controlled_term_values[ref] = term_id
 
     def add_references_to_library(self, library_data, samples):
-        """Add resolved donor references to library data based on its samples."""
-        added_donors = set()
+        """Add resolved non-controlled-term references to library data based on its samples"""
+        added_refs= set()
         for sample in samples:
             sample_api_type = self.get_api_type_from_id(sample['@id'])
             config = next(
@@ -216,7 +216,7 @@ class DB2Gatherer:
                 continue
             for field_name, ref_types in config.get('references', {}).items():
                 ref_type_list = [ref_types] if isinstance(ref_types, str) else ref_types
-                if not any(rt in ('human_donors', 'non_human_donors') for rt in ref_type_list):
+                if 'controlled_terms' in ref_type_list:
                     continue
                 for ref in self.extract_references_from_field(sample.get(field_name), field_name):
                     resolved_obj = None
@@ -224,9 +224,15 @@ class DB2Gatherer:
                         if api_type != 'ControlledTerm' and ref in objects:
                             resolved_obj = objects[ref]
                             break
-                    if resolved_obj and ref not in added_donors:
-                        library_data['donors'].append(resolved_obj)
-                        added_donors.add(ref)
+                    if resolved_obj and ref not in added_refs:
+                        bucket = None
+                        for prefix in self.configs.OBJECT_CONFIG:
+                            if f'/{prefix}/' in ref:
+                                bucket = prefix
+                                break
+                        if bucket:
+                            library_data.setdefault(bucket, []).append(resolved_obj)
+
 
     def gather_complete_library_data(self, matrix_file_set_uuid):
         """Main method: gather all data grouped by library"""
@@ -396,8 +402,8 @@ class DB2Gatherer:
             libraries_data[lib_uuid] = {
                 'library': library,
                 'samples': [],
-                'raw_matrix_files': [],
-                'donors': []
+                'raw_matrix_files': []
+                # The rest of the library data information is created on demand by setdefault in add_reference_to_library()
             }
             
             # Add samples for this library

--- a/TOOLS-285-DB2Flattener/DB2Gatherer.py
+++ b/TOOLS-285-DB2Flattener/DB2Gatherer.py
@@ -1,4 +1,11 @@
 from constants import Configs, MAX_URL_LENGTH, BASE_URL_OVERHEAD
+from DB2_utils import (
+    extract_controlled_term_id,
+    extract_uuid_from_id,
+    extract_references_from_field,
+    get_api_type_from_id,
+    get_url_prefix_from_id,
+)
 import DB2lattice
 
 
@@ -7,19 +14,6 @@ class DB2Gatherer:
         self.connection = connection
         self.configs = configs
         self.resolved_objects = {}  # {object_type: {id: object}}
-
-    def extract_uuid_from_id(self, object_id):
-        """Extract UUID from @id path like '/tissues/uuid/' -> 'uuid'"""
-        if '/' in object_id:
-            return object_id.split('/')[-2] if object_id.endswith('/') else object_id.split('/')[-1]
-        return object_id
-    
-    def get_api_type_from_id(self, object_id):
-        """Determine API type from @id path"""
-        for path_key, config in self.configs.OBJECT_CONFIG.items():
-            if f'/{path_key}/' in object_id:
-                return config['api_type']
-        return None
     
     def chunk_and_fetch(self, obj_type, object_ids):
         """Fetch objects efficiently with URL chunking if needed"""
@@ -84,48 +78,6 @@ class DB2Gatherer:
         
         return all_results
         
-    def extract_controlled_term_id(self, controlled_term_ref):
-        """Extract the semantic term ID from controlled term @id path"""
-        if '/controlled_terms/' in controlled_term_ref:
-            # Extract everything after '/controlled_terms/' and before trailing '/'
-            term_id = controlled_term_ref.split('/controlled_terms/')[-1]
-            if term_id.endswith('/'):
-                term_id = term_id[:-1]  # Remove trailing slash
-            return term_id
-        return controlled_term_ref
-    
-    def extract_references_from_field(self, field_value, field_name):
-        """Extract reference IDs from a field using FIELD_TYPES for proper handling"""
-        if not field_value:
-            return []
-        
-        field_spec = self.configs.FIELD_TYPES.get(field_name, {'type': 'string'})
-        refs = []
-        
-        if field_spec['type'] == 'array':
-            # Handle array fields
-            if isinstance(field_value, list):
-                for item in field_value:
-                    if isinstance(item, dict):
-                        # Pre-expanded object like {"@id": "/controlled_terms/xyz/", "term_name": "..."}
-                        ref_id = item.get('@id')
-                        if ref_id:
-                            refs.append(ref_id)
-                    elif isinstance(item, str):
-                        # String reference like "/controlled_terms/xyz/"
-                        refs.append(item)
-        else:
-            # Handle single value fields (type: 'string')
-            if isinstance(field_value, dict):
-                # Pre-expanded object
-                ref_id = field_value.get('@id')
-                if ref_id:
-                    refs.append(ref_id)
-            elif isinstance(field_value, str):
-                # String value or reference
-                refs.append(field_value)
-        
-        return refs
     
     def resolve_references_for_samples(self, all_samples):
         """Collect all references first, then batch fetch by type (excluding controlled terms)"""
@@ -134,7 +86,7 @@ class DB2Gatherer:
         
         # First pass: collect ALL references from samples
         for sample in all_samples.values():
-            sample_api_type = self.get_api_type_from_id(sample['@id'])
+            sample_api_type = get_api_type_from_id(sample['@id'], self.configs)
             config = None
             for cfg in self.configs.OBJECT_CONFIG.values():
                 if cfg['api_type'] == sample_api_type:
@@ -146,7 +98,7 @@ class DB2Gatherer:
             
             for field_name, ref_types in config.get('references', {}).items():
                 field_value = sample.get(field_name)
-                refs = self.extract_references_from_field(field_value, field_name)
+                refs = extract_references_from_field(field_value, field_name, self.configs)
                 
                 if isinstance(ref_types, str):
                     ref_types = [ref_types]
@@ -155,17 +107,17 @@ class DB2Gatherer:
                     if ref.startswith('/'):
                         if 'controlled_terms' in ref_types and '/controlled_terms/' in ref:
                             # Extract term ID directly for controlled terms
-                            term_id = self.extract_controlled_term_id(ref)
+                            term_id = extract_controlled_term_id(ref)
                             controlled_term_values[ref] = term_id
                         else:
                             # Regular UUID-based reference
-                            api_type = self.get_api_type_from_id(ref)
+                            api_type = get_api_type_from_id(ref, self.configs)
                             if api_type:
                                 all_reference_ids.setdefault(api_type, set()).add(ref)
         
         # Batch fetch all non-controlled-term references by type
         for api_type, ref_ids in all_reference_ids.items():
-            uuids = [self.extract_uuid_from_id(ref_id) for ref_id in ref_ids]
+            uuids = [extract_uuid_from_id(ref_id) for ref_id in ref_ids]
             ref_objects = self.chunk_and_fetch(api_type, uuids)
             
             if api_type not in self.resolved_objects:
@@ -183,7 +135,7 @@ class DB2Gatherer:
                 continue
                 
             for obj in ref_dict.values():
-                obj_api_type = self.get_api_type_from_id(obj.get('@id', ''))
+                obj_api_type = get_api_type_from_id(obj.get('@id', ''), self.configs)
                 config = None
                 for cfg in self.configs.OBJECT_CONFIG.values():
                     if cfg['api_type'] == obj_api_type:
@@ -196,18 +148,18 @@ class DB2Gatherer:
                 for field_name, ref_types in config.get('references', {}).items():
                     if 'controlled_terms' in (ref_types if isinstance(ref_types, list) else [ref_types]):
                         field_value = obj.get(field_name)
-                        refs = self.extract_references_from_field(field_value, field_name)
+                        refs = extract_references_from_field(field_value, field_name, self.configs)
                         
                         for ref in refs:
                             if ref.startswith('/controlled_terms/'):
-                                term_id = self.extract_controlled_term_id(ref)
+                                term_id = extract_controlled_term_id(ref)
                                 controlled_term_values[ref] = term_id
 
     def add_references_to_library(self, library_data, samples):
         """Add resolved non-controlled-term references to library data based on its samples"""
         added_refs= set()
         for sample in samples:
-            sample_api_type = self.get_api_type_from_id(sample['@id'])
+            sample_api_type = get_api_type_from_id(sample['@id'], self.configs)
             config = next(
                 (cfg for cfg in self.configs.OBJECT_CONFIG.values() if cfg['api_type'] == sample_api_type),
                 None,
@@ -218,20 +170,17 @@ class DB2Gatherer:
                 ref_type_list = [ref_types] if isinstance(ref_types, str) else ref_types
                 if 'controlled_terms' in ref_type_list:
                     continue
-                for ref in self.extract_references_from_field(sample.get(field_name), field_name):
+                for ref in extract_references_from_field(sample.get(field_name), field_name, self.configs):
                     resolved_obj = None
                     for api_type, objects in self.resolved_objects.items():
                         if api_type != 'ControlledTerm' and ref in objects:
                             resolved_obj = objects[ref]
                             break
                     if resolved_obj and ref not in added_refs:
-                        bucket = None
-                        for prefix in self.configs.OBJECT_CONFIG:
-                            if f'/{prefix}/' in ref:
-                                bucket = prefix
-                                break
+                        bucket = get_url_prefix_from_id(ref, self.configs)
                         if bucket:
                             library_data.setdefault(bucket, []).append(resolved_obj)
+                            added_refs.add(ref)
 
 
     def gather_complete_library_data(self, matrix_file_set_uuid):
@@ -255,7 +204,7 @@ class DB2Gatherer:
             else:
                 ref_id = ref
             if ref_id:
-                raw_matrix_uuids.append(self.extract_uuid_from_id(ref_id))
+                raw_matrix_uuids.append(extract_uuid_from_id(ref_id))
         
         print(f"Found {len(raw_matrix_uuids)} raw matrix files")
         
@@ -277,7 +226,7 @@ class DB2Gatherer:
                 else:
                     ref_id = ref
                 if ref_id:
-                    sequence_file_uuids.add(self.extract_uuid_from_id(ref_id))
+                    sequence_file_uuids.add(extract_uuid_from_id(ref_id))
         
         print(f"Found {len(sequence_file_uuids)} sequence file UUIDs referenced by raw matrix files")
         
@@ -301,7 +250,7 @@ class DB2Gatherer:
                 else:
                     ref_id = ref
                 if ref_id:
-                    file_set_uuids.add(self.extract_uuid_from_id(ref_id))
+                    file_set_uuids.add(extract_uuid_from_id(ref_id))
         
         print(f"Found {len(file_set_uuids)} file set UUIDs referenced by sequence files")
         
@@ -325,7 +274,7 @@ class DB2Gatherer:
                 else:
                     lib_id = library_ref
                 if lib_id:
-                    library_uuids.add(self.extract_uuid_from_id(lib_id))
+                    library_uuids.add(extract_uuid_from_id(lib_id))
         
         print(f"Found {len(library_uuids)} library UUIDs referenced by file sets")
         
@@ -342,7 +291,7 @@ class DB2Gatherer:
                 else:
                     lib_id = library_ref
                 
-                lib_uuid = self.extract_uuid_from_id(lib_id)
+                lib_uuid = extract_uuid_from_id(lib_id)
                 if lib_uuid in library_uuids:
                     # Determine type from the @id path
                     if '/droplet_based_libraries/' in lib_id:
@@ -376,11 +325,11 @@ class DB2Gatherer:
                     ref_id = ref
                 
                 if ref_id:
-                    api_type = self.get_api_type_from_id(ref_id)
+                    api_type = get_api_type_from_id(ref_id, self.configs)
                     if api_type:
                         if api_type not in sample_uuids_by_type:
                             sample_uuids_by_type[api_type] = []
-                        sample_uuids_by_type[api_type].append(self.extract_uuid_from_id(ref_id))
+                        sample_uuids_by_type[api_type].append(extract_uuid_from_id(ref_id))
         
         # Fetch all sample types
         all_samples = {}
@@ -403,7 +352,7 @@ class DB2Gatherer:
                 'library': library,
                 'samples': [],
                 'raw_matrix_files': []
-                # The rest of the library data information is created on demand by setdefault in add_reference_to_library()
+                # The rest of the library data information is created on demand by setdefault in add_references_to_library()
             }
             
             # Add samples for this library
@@ -470,7 +419,7 @@ class DB2Gatherer:
                                 else:
                                     lib_id = library_ref
                                 
-                                lib_uuid = self.extract_uuid_from_id(lib_id)
+                                lib_uuid = extract_uuid_from_id(lib_id)
                                 if lib_uuid in libraries_data and lib_uuid not in matched_libraries:
                                     matched_libraries.append(lib_uuid)
             

--- a/TOOLS-285-DB2Flattener/DB2_utils.py
+++ b/TOOLS-285-DB2Flattener/DB2_utils.py
@@ -1,11 +1,17 @@
 """
-Generic DataFrame transforms for DB2 builders.
+Generic functions for gathering DB2 object information, and DataFrame transforms for DB2 builder
 
 - Split embedded controlled-term dicts into _term_id / _term_name columns
 - Collapse rows by a group key (scalar or list per cell)
+- Get url prefix from an object id
+- Get API type from an object id
+- Get object type from object id
+- Get uuid from object id
+- Get reference object ids from a field
 """
 
 import pandas as pd
+from constants import Configs
 
 TERM_ID_SUFFIX = "_term_id"
 TERM_NAME_SUFFIX = "_term_name"
@@ -52,20 +58,6 @@ def collapse_dataframe(
     other_cols = columns or [c for c in df.columns if c != group_col]
     agg = {col: single_or_list for col in other_cols}
     return df.groupby(group_col, as_index=False).agg(agg)
-
-
-def extract_term_id_from_ref(ref: str):
-    """
-    Parse semantic term ID from a controlled-term @id path.
-
-    Example: '/controlled_terms/EFO:0920086/' -> 'EFO:0920086'
-    """
-    if not ref:
-        return pd.NA
-    if "/controlled_terms/" in ref:
-        term_id = ref.split("/controlled_terms/")[-1]
-        return term_id.rstrip("/")
-    return ref
 
 
 def cell_has_term_name_structure(val) -> bool:
@@ -117,7 +109,7 @@ def split_term_cell(val):
     if not dicts:
         return pd.NA, pd.NA
 
-    term_ids = [extract_term_id_from_ref(d.get("@id", "")) for d in dicts]
+    term_ids = [extract_controlled_term_id(d.get("@id", "")) for d in dicts]
     term_names = [d["term_name"] for d in dicts]
 
     if len(dicts) == 1:
@@ -149,3 +141,86 @@ def split_controlled_term_columns(df: pd.DataFrame) -> pd.DataFrame:
 
     print(f"Split controlled-term columns: {term_cols}")
     return out
+
+
+# Gathering DB2 Objects generic functions
+
+def extract_controlled_term_id(ref: str):
+    """
+    Parse semantic term ID from a controlled-term @id path.
+
+    Example: '/controlled_terms/EFO:0920086/' -> 'EFO:0920086'
+    """
+    if not ref:
+        return pd.NA
+    if "/controlled_terms/" in ref:
+        term_id = ref.split("/controlled_terms/")[-1]
+        return term_id.rstrip("/")
+    return ref
+
+
+def match_object_config_from_id(object_id: str, configs: Configs):
+    """Return (url_prefix, config) for an @id path, or (None, None)."""
+    if not object_id:
+        return None, None
+    for path_key, config in configs.OBJECT_CONFIG.items():
+        if f'/{path_key}/' in object_id:
+            return path_key, config
+    return None, None
+
+
+def get_url_prefix_from_id(object_id: str, configs: Configs):
+    """'/human_donors/uuid/' -> 'human_donors'"""
+    prefix, _ = match_object_config_from_id(object_id, configs)
+    return prefix
+
+
+def get_api_type_from_id(object_id: str, configs: Configs):
+    """'/human_donors/uuid/' -> 'HumanDonor'"""
+    _, config = match_object_config_from_id(object_id, configs)
+    return config['api_type'] if config else None
+
+
+def get_config_obj_type(obj: dict, configs: Configs) -> str:
+    """Map a resolved object to OBJECT_CONFIG url_prefix via @id, else @type."""
+    obj_id = obj.get('@id', '')
+    if obj_id:
+        prefix = get_url_prefix_from_id(obj_id, configs)
+        if prefix:
+            return prefix
+    for config_obj_type, config_obj_info in configs.OBJECT_CONFIG.items():
+        if config_obj_info.get('api_type', '') == obj.get('@type', [''])[0]:
+            return config_obj_type
+    return ''
+
+
+def extract_uuid_from_id(object_id: str) -> str:
+    """'/tissues/uuid/' -> 'uuid'"""
+    if '/' in object_id:
+        return object_id.split('/')[-2] if object_id.endswith('/') else object_id.split('/')[-1]
+    return object_id
+
+
+def extract_references_from_field(field_value, field_name, configs: Configs) -> list:
+    """Extract reference @id paths from a field using FIELD_TYPES."""
+    if not field_value:
+        return []
+    field_spec = configs.FIELD_TYPES.get(field_name, {'type': 'string'})
+    refs = []
+    if field_spec['type'] == 'array':
+        if isinstance(field_value, list):
+            for item in field_value:
+                if isinstance(item, dict):
+                    ref_id = item.get('@id')
+                    if ref_id:
+                        refs.append(ref_id)
+                elif isinstance(item, str):
+                    refs.append(item)
+    else:
+        if isinstance(field_value, dict):
+            ref_id = field_value.get('@id')
+            if ref_id:
+                refs.append(ref_id)
+        elif isinstance(field_value, str):
+            refs.append(field_value)
+    return refs

--- a/TOOLS-285-DB2Flattener/constants.py
+++ b/TOOLS-285-DB2Flattener/constants.py
@@ -57,12 +57,3 @@ PROP_MAP_GEO = {
     'raw_matrix_file_alias': 'raw_file',
     'droplet_based_libraries_library_cardinality': 'single or paired-end'
 }
-
-# API types to resolve when walking sample references.
-# Controlled terms are always parsed from paths and never fetched here.
-FETCHED_SAMPLE_REFERENCE_API_TYPES = frozenset({
-    'HumanDonor',
-    'NonHumanDonor',
-})
-
-

--- a/TOOLS-285-DB2Flattener/constants.py
+++ b/TOOLS-285-DB2Flattener/constants.py
@@ -39,6 +39,11 @@ class Configs:
     OBJECT_CONFIG: ObjectConfig
 
 
+# Audit/provenance fields present on nearly every Lattice schema profile.
+# Excluded from OBJECT_CONFIG so they don't get flattened into a column
+# (and, in submitted_by's case, resolved as a reference) for every object type.
+EXCLUDED_FIELDS = {'creation_timestamp', 'submitted_by'}
+
 # URL length limit for chunking (includes base URL overhead)
 MAX_URL_LENGTH = 3800
 # Base URL overhead for chunking calculations (base URL + field params + safety margin)

--- a/TOOLS-285-DB2Flattener/constants.py
+++ b/TOOLS-285-DB2Flattener/constants.py
@@ -44,7 +44,7 @@ MAX_URL_LENGTH = 3800
 # Base URL overhead for chunking calculations (base URL + field params + safety margin)
 BASE_URL_OVERHEAD = 700
 
-# Keys use _term_name suffix for columns produced by df_utils.split_controlled_term_columns
+# Keys use _term_name suffix for columns produced by DB2_utils.split_controlled_term_columns
 PROP_MAP_GEO = {
     'droplet_based_libraries_CRO_group_identifier': '*library name',
     'droplet_based_libraries_library_construction_technology_term_name': '*library strategy',

--- a/TOOLS-285-DB2Flattener/generate_constants.py
+++ b/TOOLS-285-DB2Flattener/generate_constants.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from typing import Any
 
 import yaml
-from constants import FieldTypes, Hierarchy, JSONProfile, ObjectConfig
+from constants import EXCLUDED_FIELDS, FieldTypes, Hierarchy, JSONProfile, ObjectConfig
 from DB2lattice import Connection
 from extract_lattice_profiles import (
     LatticeProfileClient,
@@ -138,10 +138,15 @@ def create_object_config(profiles: JSONProfile) -> ObjectConfig:
         references_values: dict[str, str | list[str]] = {}
         slug = schema["slug"]
         schema_ids = SchemaIDs(slug)
-        fields = [field["name"] for field in schema["properties"]]
+        fields = [
+            field["name"] for field in schema["properties"]
+            if field["name"] not in EXCLUDED_FIELDS
+        ]
 
         for field in schema["properties"]:
             field_name = field["name"]
+            if field_name in EXCLUDED_FIELDS:
+                continue
             link_to = field["link_to"]
             if link_to is not None:
                 references = get_concrete_classes(link_to, hierarchy)

--- a/TOOLS-285-DB2Flattener/tests/test_create_dataframe.py
+++ b/TOOLS-285-DB2Flattener/tests/test_create_dataframe.py
@@ -1,0 +1,183 @@
+import pandas as pd
+import pytest
+
+from constants import Configs
+from DB2Flattener import DB2Flattener
+
+
+MIN_CONFIGS = Configs(
+    FIELD_TYPES={},
+    OBJECT_CONFIG={
+        'droplet_based_libraries': {
+            'api_type': 'DropletBasedLibrary',
+            'fields': ['@id', 'feature_types', 'CRO_group_identifier', 'aliases'],
+            'references': {},
+        },
+        'tissues': {
+            'api_type': 'Tissue',
+            'fields': ['@id', 'aliases', 'author_metadata'],
+            'references': {},
+        },
+    },
+)
+
+
+def make_flattener():
+    f = DB2Flattener.__new__(DB2Flattener)
+    f.connection = None
+    f.configs = MIN_CONFIGS
+    f.gatherer = None
+    return f
+
+
+def _tissue(sample_id='/tissues/s1/', alias='lab:sample1', author_metadata=None):
+    return {
+        '@id': sample_id,
+        '@type': ['Tissue'],
+        'aliases': [alias],
+        'author_metadata': author_metadata,
+    }
+
+
+def _lib(lib_id, feature_types, cro='RSJS_fast_1', alias=None):
+    return {
+        '@id': lib_id,
+        '@type': ['DropletBasedLibrary'],
+        'feature_types': feature_types,
+        'CRO_group_identifier': cro,
+        'aliases': [alias or f'lab:{feature_types[0].replace(" ", "_")}'],
+    }
+
+
+def _rmf(rmf_id='/raw_matrix_files/r1/', alias='lab:rmf1', sample_id='/tissues/s1/'):
+    return {
+        '@id': rmf_id,
+        'aliases': [alias],
+        'samples': [sample_id],
+    }
+
+
+def _complete_data(libs_with_rmfs):
+    """libs_with_rmfs: list of (library, [raw_matrix_files], [samples])"""
+    libraries = {}
+    for i, (lib, rmfs, samples) in enumerate(libs_with_rmfs):
+        libraries[f'uuid-{i}'] = {
+            'library': lib,
+            'raw_matrix_files': rmfs,
+            'samples': samples,
+        }
+    return {'libraries': libraries, 'resolved_objects': {'ControlledTerm': {}}}
+
+
+# --- _row_is_gex (new method) ---
+
+@pytest.mark.parametrize(
+    'row,expected',
+    [
+        ({'droplet_based_libraries_feature_types': ['Gene Expression']}, True),
+        ({'droplet_based_libraries_feature_types': ['CRISPR Guide Capture']}, False),
+        ({'droplet_based_libraries_feature_types': 'Gene Expression'}, True),
+        ({'plate_based_libraries_feature_types': ['Gene Expression']}, True),
+        # missing FT: plate assumed GEX
+        ({'plate_based_libraries_@id': '/plate_based_libraries/p1/'}, True),
+        # missing FT: droplet assumed non-GEX
+        ({'droplet_based_libraries_@id': '/droplet_based_libraries/d1/'}, False),
+    ],
+)
+def test_row_is_gex(row, expected):
+    f = make_flattener()
+    assert f._row_is_gex(pd.Series(row)) is expected
+
+
+# --- create_dataframe: one row per (RMF, library) ---
+
+def test_create_dataframe_one_row_per_rmf_library():
+    f = make_flattener()
+    sample = _tissue()
+    rmf = _rmf()
+    gex = _lib('/droplet_based_libraries/gex/', ['Gene Expression'], alias='lab:gex')
+    cri = _lib('/droplet_based_libraries/cri/', ['CRISPR Guide Capture'], alias='lab:cri')
+
+    main_df, sample_df = f.create_dataframe(_complete_data([
+        (gex, [rmf], [sample]),
+        (cri, [rmf], [sample]),
+    ]))
+
+    assert len(main_df) == 2
+    assert set(main_df['droplet_based_libraries_@id']) == {
+        '/droplet_based_libraries/gex/',
+        '/droplet_based_libraries/cri/',
+    }
+    assert set(main_df['raw_matrix_file_alias']) == {'rmf1'}
+    ftypes = set()
+    for ft in main_df['droplet_based_libraries_feature_types']:
+        ftypes.update(ft if isinstance(ft, list) else [ft])
+    assert 'Gene Expression' in ftypes
+    assert 'CRISPR Guide Capture' in ftypes
+
+
+def test_create_dataframe_dedupes_same_library_twice_on_rmf():
+    """Same lib attached via two library buckets should not double MAIN rows."""
+    f = make_flattener()
+    sample = _tissue()
+    rmf = _rmf()
+    gex = _lib('/droplet_based_libraries/gex/', ['Gene Expression'])
+
+    main_df, _ = f.create_dataframe(_complete_data([
+        (gex, [rmf], [sample]),
+        (gex, [rmf], [sample]),
+    ]))
+
+    assert len(main_df) == 1
+    assert main_df.iloc[0]['droplet_based_libraries_@id'] == '/droplet_based_libraries/gex/'
+
+
+def test_sample_df_not_inflated_when_rmf_has_two_libraries():
+    f = make_flattener()
+    sample = _tissue()
+    rmf = _rmf()
+    gex = _lib('/droplet_based_libraries/gex/', ['Gene Expression'], alias='lab:gex')
+    cri = _lib('/droplet_based_libraries/cri/', ['CRISPR Guide Capture'], alias='lab:cri')
+
+    main_df, sample_df = f.create_dataframe(_complete_data([
+        (gex, [rmf], [sample]),
+        (cri, [rmf], [sample]),
+    ]))
+
+    assert len(main_df) == 2
+    assert sample_df is not None
+    assert sample_df.reset_index()['raw_matrix_file_alias'].nunique() == 1
+    assert len(sample_df) == 1
+
+
+# --- author_metadata explode ---
+
+def test_author_metadata_dict_exploded_to_columns():
+    f = make_flattener()
+    sample = _tissue(author_metadata={'mouse litter batch': 'A1', 'diet': 'fasted'})
+    rmf = _rmf()
+    gex = _lib('/droplet_based_libraries/gex/', ['Gene Expression'])
+
+    main_df, _ = f.create_dataframe(_complete_data([
+        (gex, [rmf], [sample]),
+    ]))
+
+    assert 'tissues_mouse_litter_batch' in main_df.columns
+    assert 'tissues_diet' in main_df.columns
+    assert main_df.iloc[0]['tissues_mouse_litter_batch'] == 'A1'
+    assert main_df.iloc[0]['tissues_diet'] == 'fasted'
+    assert 'tissues_author_metadata' not in main_df.columns
+
+
+def test_author_metadata_non_dict_kept_as_normal_field():
+    f = make_flattener()
+    sample = _tissue(author_metadata=None)
+    rmf = _rmf()
+    gex = _lib('/droplet_based_libraries/gex/', ['Gene Expression'])
+
+    main_df, _ = f.create_dataframe(_complete_data([
+        (gex, [rmf], [sample]),
+    ]))
+
+    assert 'tissues_author_metadata' in main_df.columns
+    assert 'tissues_mouse_litter_batch' not in main_df.columns

--- a/TOOLS-285-DB2Flattener/tests/test_create_dataframe_updates.py
+++ b/TOOLS-285-DB2Flattener/tests/test_create_dataframe_updates.py
@@ -1,0 +1,183 @@
+import pandas as pd
+import pytest
+
+from constants import Configs
+from DB2Flattener import DB2Flattener
+
+
+MIN_CONFIGS = Configs(
+    FIELD_TYPES={},
+    OBJECT_CONFIG={
+        'droplet_based_libraries': {
+            'api_type': 'DropletBasedLibrary',
+            'fields': ['@id', 'feature_types', 'CRO_group_identifier', 'aliases'],
+            'references': {},
+        },
+        'tissues': {
+            'api_type': 'Tissue',
+            'fields': ['@id', 'aliases', 'author_metadata'],
+            'references': {},
+        },
+    },
+)
+
+
+def make_flattener():
+    f = DB2Flattener.__new__(DB2Flattener)
+    f.connection = None
+    f.configs = MIN_CONFIGS
+    f.gatherer = None
+    return f
+
+
+def _tissue(sample_id='/tissues/s1/', alias='lab:sample1', author_metadata=None):
+    return {
+        '@id': sample_id,
+        '@type': ['Tissue'],
+        'aliases': [alias],
+        'author_metadata': author_metadata,
+    }
+
+
+def _lib(lib_id, feature_types, cro='RSJS_fast_1', alias=None):
+    return {
+        '@id': lib_id,
+        '@type': ['DropletBasedLibrary'],
+        'feature_types': feature_types,
+        'CRO_group_identifier': cro,
+        'aliases': [alias or f'lab:{feature_types[0].replace(" ", "_")}'],
+    }
+
+
+def _rmf(rmf_id='/raw_matrix_files/r1/', alias='lab:rmf1', sample_id='/tissues/s1/'):
+    return {
+        '@id': rmf_id,
+        'aliases': [alias],
+        'samples': [sample_id],
+    }
+
+
+def _complete_data(libs_with_rmfs):
+    """libs_with_rmfs: list of (library, [raw_matrix_files], [samples])"""
+    libraries = {}
+    for i, (lib, rmfs, samples) in enumerate(libs_with_rmfs):
+        libraries[f'uuid-{i}'] = {
+            'library': lib,
+            'raw_matrix_files': rmfs,
+            'samples': samples,
+        }
+    return {'libraries': libraries, 'resolved_objects': {'ControlledTerm': {}}}
+
+
+# --- _row_is_gex (new method) ---
+
+@pytest.mark.parametrize(
+    'row,expected',
+    [
+        ({'droplet_based_libraries_feature_types': ['Gene Expression']}, True),
+        ({'droplet_based_libraries_feature_types': ['CRISPR Guide Capture']}, False),
+        ({'droplet_based_libraries_feature_types': 'Gene Expression'}, True),
+        ({'plate_based_libraries_feature_types': ['Gene Expression']}, True),
+        # missing FT: plate assumed GEX
+        ({'plate_based_libraries_@id': '/plate_based_libraries/p1/'}, True),
+        # missing FT: droplet assumed non-GEX
+        ({'droplet_based_libraries_@id': '/droplet_based_libraries/d1/'}, False),
+    ],
+)
+def test_row_is_gex(row, expected):
+    f = make_flattener()
+    assert f._row_is_gex(pd.Series(row)) is expected
+
+
+# --- create_dataframe: one row per (RMF, library) ---
+
+def test_create_dataframe_one_row_per_rmf_library():
+    f = make_flattener()
+    sample = _tissue()
+    rmf = _rmf()
+    gex = _lib('/droplet_based_libraries/gex/', ['Gene Expression'], alias='lab:gex')
+    cri = _lib('/droplet_based_libraries/cri/', ['CRISPR Guide Capture'], alias='lab:cri')
+
+    main_df, sample_df = f.create_dataframe(_complete_data([
+        (gex, [rmf], [sample]),
+        (cri, [rmf], [sample]),
+    ]))
+
+    assert len(main_df) == 2
+    assert set(main_df['droplet_based_libraries_@id']) == {
+        '/droplet_based_libraries/gex/',
+        '/droplet_based_libraries/cri/',
+    }
+    assert set(main_df['raw_matrix_file_alias']) == {'rmf1'}
+    ftypes = set()
+    for ft in main_df['droplet_based_libraries_feature_types']:
+        ftypes.update(ft if isinstance(ft, list) else [ft])
+    assert 'Gene Expression' in ftypes
+    assert 'CRISPR Guide Capture' in ftypes
+
+
+def test_create_dataframe_dedupes_same_library_twice_on_rmf():
+    """Same lib attached via two library buckets should not double MAIN rows."""
+    f = make_flattener()
+    sample = _tissue()
+    rmf = _rmf()
+    gex = _lib('/droplet_based_libraries/gex/', ['Gene Expression'])
+
+    main_df, _ = f.create_dataframe(_complete_data([
+        (gex, [rmf], [sample]),
+        (gex, [rmf], [sample]),
+    ]))
+
+    assert len(main_df) == 1
+    assert main_df.iloc[0]['droplet_based_libraries_@id'] == '/droplet_based_libraries/gex/'
+
+
+def test_sample_df_not_inflated_when_rmf_has_two_libraries():
+    f = make_flattener()
+    sample = _tissue()
+    rmf = _rmf()
+    gex = _lib('/droplet_based_libraries/gex/', ['Gene Expression'], alias='lab:gex')
+    cri = _lib('/droplet_based_libraries/cri/', ['CRISPR Guide Capture'], alias='lab:cri')
+
+    main_df, sample_df = f.create_dataframe(_complete_data([
+        (gex, [rmf], [sample]),
+        (cri, [rmf], [sample]),
+    ]))
+
+    assert len(main_df) == 2
+    assert sample_df is not None
+    assert sample_df.reset_index()['raw_matrix_file_alias'].nunique() == 1
+    assert len(sample_df) == 1
+
+
+# --- author_metadata explode ---
+
+def test_author_metadata_dict_exploded_to_columns():
+    f = make_flattener()
+    sample = _tissue(author_metadata={'mouse litter batch': 'A1', 'diet': 'fasted'})
+    rmf = _rmf()
+    gex = _lib('/droplet_based_libraries/gex/', ['Gene Expression'])
+
+    main_df, _ = f.create_dataframe(_complete_data([
+        (gex, [rmf], [sample]),
+    ]))
+
+    assert 'tissues_mouse_litter_batch' in main_df.columns
+    assert 'tissues_diet' in main_df.columns
+    assert main_df.iloc[0]['tissues_mouse_litter_batch'] == 'A1'
+    assert main_df.iloc[0]['tissues_diet'] == 'fasted'
+    assert 'tissues_author_metadata' not in main_df.columns
+
+
+def test_author_metadata_non_dict_kept_as_normal_field():
+    f = make_flattener()
+    sample = _tissue(author_metadata=None)
+    rmf = _rmf()
+    gex = _lib('/droplet_based_libraries/gex/', ['Gene Expression'])
+
+    main_df, _ = f.create_dataframe(_complete_data([
+        (gex, [rmf], [sample]),
+    ]))
+
+    assert 'tissues_author_metadata' in main_df.columns
+    assert 'tissues_mouse_litter_batch' not in main_df.columns


### PR DESCRIPTION
- Adjusted the reference handling to gather all reference objects assigned by constants, and still perform batch gathering by object type. 

- Changed the handling in Flattener.py to not filter GEX Libraries for the MAIN dataframe. To filter GEX files, follows previous implementation of filtering.

- Added filtering of GEX libraries for the GEO dataframe.

- Addressed last donor overwriting bug. Values are now made into lists if there’s multiple samples in the donor.

- Added a check for ‘author_metadata’ field during creation of the MAIN dataframe, and adjusted how the column header and value is set accordingly.

- Adjusted creation of OBJECT_CONFIG by filtering out '_creation_timestamp' and '_submitted_by' fields, so they don't end up in the main dataframe.


