### PR TITLE
TOOLS-319 Pin ruff to 0.16.1 and select lint rules explicitly

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,8 +12,10 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.11'
+      # Keep this version in sync with .pre-commit-config.yaml so local hooks and
+      # CI agree. An unpinned ruff silently picks up new rules on release.
       - name: Install ruff
-        run: pip install ruff
+        run: pip install ruff==0.16.1
       - name: Run ruff check
         run: ruff check bcp/
       - name: Run ruff format check

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,10 +2,14 @@
 # Install: pip install pre-commit && pre-commit install
 # Run manually: pre-commit run --all-files
 #
-# Ruff uses config from pyproject.toml (target-version, line-length, exclude).
+# Ruff uses config from pyproject.toml (target-version, line-length, exclude, lint.select).
 # Format hook *writes* fixes (ruff format); CI still uses `ruff format --check`
 # so unformatted code cannot merge. Lint is check-only here; use `ruff check --fix`
 # locally if you want the same auto-fix behavior for fixable rules.
+#
+# The ruff hooks pin their own ruff via additional_dependencies rather than using
+# whatever is on PATH, so every developer and CI lint with the identical binary.
+# Keep the version in sync with .github/workflows/tests.yml.
 
 repos:
   # 1) Ruff format bcp/ — auto-fix on commit (not --check; that only fails)
@@ -14,7 +18,8 @@ repos:
       - id: ruff-format-bcp
         name: ruff format bcp/
         entry: ruff format bcp/
-        language: system
+        language: python
+        additional_dependencies: ["ruff==0.16.1"]
         pass_filenames: false
 
   # 2) Ruff lint on bcp/ (same as CI: ruff check bcp/)
@@ -23,7 +28,8 @@ repos:
       - id: ruff-check-bcp
         name: ruff check bcp/
         entry: ruff check bcp/
-        language: system
+        language: python
+        additional_dependencies: ["ruff==0.16.1"]
         pass_filenames: false
 
   # 3) Full pytest suite under bcp/tests (same as CI). Requires bcp deps on PATH

--- a/bcp/E2E_TESTS.md
+++ b/bcp/E2E_TESTS.md
@@ -192,9 +192,8 @@ If guide5 returns NA, check that test_guides.txt includes the 5th guide.
    pytestmark = [
        pytest.mark.e2e,
        pytest.mark.skipif(
-           not is_guidescan_available(),
-           reason="guidescan not available in PATH"
-       )
+           not is_guidescan_available(), reason="guidescan not available in PATH"
+       ),
    ]
    ```
 

--- a/bcp/README.md
+++ b/bcp/README.md
@@ -192,7 +192,7 @@ pipeline = GuidescanPipeline(
     guides_file="guides.txt",
     output_dir="results/",
     keep_intermediate=True,
-    verbose=True
+    verbose=True,
 )
 
 # Run complete pipeline
@@ -507,7 +507,7 @@ from guide_to_gene_bioframe import annotate_guides_bioframe
 annotate_guides_bioframe(
     guide_file="results/exact_matches_formatted.csv",
     gtf_file="/path/to/genes.gtf",
-    output_file="results/guides_annotated.csv"
+    output_file="results/guides_annotated.csv",
 )
 ```
 

--- a/bcp/TESTING.md
+++ b/bcp/TESTING.md
@@ -134,11 +134,11 @@ Test workflow orchestration using:
 ### Mocking Approach
 ```python
 # Mock guidescan execution
-with patch.object(GuidescanPipeline, 'run_guidescan', mock_function):
+with patch.object(GuidescanPipeline, "run_guidescan", mock_function):
     result = pipeline.run()
 
 # Mock subprocess calls
-with patch('subprocess.run'):
+with patch("subprocess.run"):
     pipeline.validate_inputs()
 ```
 
@@ -218,15 +218,16 @@ pytest -x
 import pytest
 from guidescan_pipeline import GuidescanPipeline
 
+
 class TestNewFeature:
     def test_new_functionality(self, temp_dir, dummy_genome_index):
         """Test description."""
         # Arrange
         pipeline = GuidescanPipeline(...)
-        
+
         # Act
         result = pipeline.new_method()
-        
+
         # Assert
         assert result == expected
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,3 +2,9 @@
 target-version = "py311"
 line-length = 88
 exclude = ["__pycache__", ".git", ".pytest_cache", "*.ipynb"]
+
+# Selected explicitly rather than relying on Ruff's defaults: 0.16.0 expanded the
+# default set from 59 to 413 rules, which silently changes what CI enforces on a
+# version bump. These four are the pre-0.16 defaults.
+[tool.ruff.lint]
+select = ["E4", "E7", "E9", "F"]


### PR DESCRIPTION
## Summary

Ruff 0.16.0 expanded its default rule set from 59 to 413 rules. Because CI installed ruff unpinned, every branch has failed the lint job since that release on 209 pre-existing violations unrelated to its own changes. Pre-commit used `language: system` and resolved to whichever ruff a developer had on PATH, so it reported green on code CI rejected.

This pins the version in both places and declares the rule selection explicitly, making enforcement deterministic and decoupled from the ruff version. The selected rules are the pre-0.16 defaults, so this restores previously enforced behavior rather than introducing a new standard.

## Changes

- `pyproject.toml` — add `[tool.ruff.lint] select = ["E4", "E7", "E9", "F"]`, the pre-0.16 default set
- `.github/workflows/tests.yml` — pin `pip install ruff==0.16.1`
- `.pre-commit-config.yaml` — both ruff hooks move from `language: system` to `language: python` with `additional_dependencies: ["ruff==0.16.1"]`, so local hooks and CI use an identical binary. The `pytest-bcp` hook stays on `system` since it needs the conda env with bcp deps.
- `bcp/E2E_TESTS.md`, `bcp/README.md`, `bcp/TESTING.md` — apply the 0.16 formatter, which formats Python code blocks inside Markdown (earlier versions did not). Fenced code blocks only: trailing commas, quote normalization, whitespace. No prose changes.

## Verification

CI is green. Worth noting that `Run ruff format check` and the `bcp-pytest` job actually **execute** here for the first time in weeks; they had been skipped because `ruff check` failed first, so the format step was never validated on 0.16.

Locally with the pinned 0.16.1:

- `ruff check bcp/` — All checks passed
- `ruff format --check bcp/` — 78 files already formatted
- `pytest tests/` — 667 passed, 13 skipped
- `pre-commit run --all-files` — all three hooks pass; hook env confirmed resolving to ruff 0.16.1 rather than the local conda 0.15.6

## Notes

- Merging unblocks the lint job for the other currently-red branches (`TOOLS-317`, `batch_download`, `TOOLS-311`, `TOOLS-313`, `TOOLS-301`), which all fail on this same step.
- This deliberately does **not** adopt the new 0.16 defaults. That is 209 violations (173 auto-fixable, ~36 needing judgment) and is planned as a separate branch. It should land *after* `tools-318` merges: 87 of the 209 sit in `validators.py`, `cli.py`, and `sif_io.py`, which `tools-318` adds 500+ lines to.
- The two version pins must stay in sync; both files carry a comment saying so.

Made with [Cursor](https://cursor.com)