### PR TITLE
Adjusted _map_raw_matrix_files_to_libraries in gatherer.py to also st…

### DIFF
--- a/TOOLS-285-DB2Flattener/DB2Flattener.py
+++ b/TOOLS-285-DB2Flattener/DB2Flattener.py
@@ -110,15 +110,14 @@ class DB2Flattener:
                 raw_file_id = raw_file.get('@id')
                 if raw_file_id not in raw_file_to_libraries:
                     raw_file_to_libraries[raw_file_id] = {
-                        'raw_file': raw_file,
-                        'libraries': [],
+                        'library_entries': [],
                         'all_samples': []
                     }
                 
-                # Add this library's data to the raw matrix file (once per @id to prevent duplicates)
-                existing_lib_ids = {lib.get('@id') for lib in raw_file_to_libraries[raw_file_id]['libraries']}
+                # Add this library's data to the raw matrix file
+                existing_lib_ids = {entry['library'].get('@id') for entry in raw_file_to_libraries[raw_file_id]['library_entries']}
                 if library.get('@id') not in existing_lib_ids:
-                    raw_file_to_libraries[raw_file_id]['libraries'].append(library)
+                    raw_file_to_libraries[raw_file_id]['library_entries'].append({'library': library, 'raw_file': raw_file})
                 raw_file_to_libraries[raw_file_id]['all_samples'].extend(samples)
                 
                 # Collect per-sample metadata for later merge with raw matrix files
@@ -160,27 +159,41 @@ class DB2Flattener:
 
         # Create one row per (raw matrix file, library)
         for file_data in raw_file_to_libraries.values():
-            raw_file = file_data['raw_file']
-            libraries = file_data['libraries']
+            library_entries = file_data['library_entries']
             samples = file_data['all_samples']
 
+            # For raw_matrix_file_alias and raw_file_samples, it doesn't matter which raw file copy we use
+            # As they will all have the same value
+            representative_raw_file = library_entries[0]['raw_file']
             sample_aliases = []
-            for sample_ref in raw_file.get('samples', []):
+            for sample_ref in representative_raw_file.get('samples', []):
                 sample_obj = next((s for s in samples if s.get('@id') == sample_ref), None)
                 if sample_obj:
                     sample_aliases.append(self._get_clean_alias(sample_obj))
 
             shared = {
-                'raw_matrix_file_alias': self._get_clean_alias(raw_file),
+                'raw_matrix_file_alias': self._get_clean_alias(representative_raw_file),
                 'raw_file_samples': self._join_unique(sample_aliases),
             }
 
-            for lib in libraries:
+            for entry in library_entries:
+                lib = entry['library']
+                # This libraries scoped copy of the raw matrix file
+                # Which has the library specific sequence_file and sequence_file_set metadata
+                raw_file = entry['raw_file']
                 row = dict(shared)
                 lib_type = get_config_obj_type(lib, self.configs)
                 for field in self.configs.OBJECT_CONFIG[lib_type].get('fields', []):
-                    field_name = f'{lib_type}_{field}'
-                    row[field_name] = lib.get(field)
+                    row[f'{lib_type}_{field}'] = lib.get(field)
+
+                for obj_type in ('sequence_files', 'sequence_file_sets'):
+                    obj_config = self.configs.OBJECT_CONFIG.get(obj_type, {})
+                    for obj_field in obj_config.get('fields', []):
+                        values = [
+                            obj.get(obj_field) for obj in raw_file.get(obj_type, [])
+                            if obj.get(obj_field) not in (None, '')
+                        ]
+                        row[f'{obj_type}_{obj_field}'] = self._join_unique(values) if values else None
                 rows.append(row)
         
         main_df = pd.DataFrame(rows)

--- a/TOOLS-285-DB2Flattener/DB2Flattener.py
+++ b/TOOLS-285-DB2Flattener/DB2Flattener.py
@@ -391,8 +391,16 @@ class DB2Flattener:
     
     def _join_unique(self, items):
         """Join unique non-empty items with semicolon"""
+        # Flatten any list-valued items (e.g. array-typed fields) before stringifying
+        flattened_items = []
+        for item in items:
+            if isinstance(item, list):
+                flattened_items.extend(item)
+            else:
+                flattened_items.append(item)
+
         # Filter out empty/None values
-        filtered_items = [str(item).strip() for item in items if item and str(item).strip()]
+        filtered_items = [str(item).strip() for item in flattened_items if item and str(item).strip()]
         
         if not filtered_items:
             return

--- a/TOOLS-285-DB2Flattener/DB2Gatherer.py
+++ b/TOOLS-285-DB2Flattener/DB2Gatherer.py
@@ -387,7 +387,7 @@ class DB2Gatherer:
         """Map raw matrix files to their corresponding libraries using samples field or data flow"""
         
         for raw_file in raw_matrix_files:
-            matched_libraries = []
+            matched_data = {}
             
             # Raw matrix file -> sequence files (via derived_from)
             derived_from = raw_file.get('derived_from', [])
@@ -420,9 +420,16 @@ class DB2Gatherer:
                                     lib_id = library_ref
                                 
                                 lib_uuid = extract_uuid_from_id(lib_id)
-                                if lib_uuid in libraries_data and lib_uuid not in matched_libraries:
-                                    matched_libraries.append(lib_uuid)
+                                # Record lib_uuid of libraries found, along with the sequence file and file sets used to get to it
+                                if lib_uuid in libraries_data:
+                                    bucket = matched_data.setdefault(lib_uuid, {'sequence_files': {}, 
+                                                                                'sequence_file_sets': {}})
+                                    bucket['sequence_files'][seq_file.get('@id', '')] = seq_file
+                                    bucket['sequence_file_sets'][file_set.get('@id', '')] = file_set
             
-            # Add the raw matrix file to ALL matched libraries
-            for lib_uuid in matched_libraries:
-                libraries_data[lib_uuid]['raw_matrix_files'].append(raw_file)
+            # Add a sequence_file and sequence_file_set path specific copy of raw matrix file to each library
+            for lib_uuid, bucket in matched_data.items():
+                raw_file_copy = dict(raw_file)
+                raw_file_copy['sequence_files'] = list(bucket['sequence_files'].values())
+                raw_file_copy['sequence_file_sets'] = list(bucket['sequence_file_sets'].values())
+                libraries_data[lib_uuid]['raw_matrix_files'].append(raw_file_copy)


### PR DESCRIPTION
Adjusted _map_raw_matrix_files_to_libraries in gatherer.py to also store the sequence_file and sequence_file_set used to get to that library in the mapping. This way, when going back through the mapping to add raw matrix file objects to the library data, it adds the specific sequence_file and sequence_file_sets along with the raw file. 

Changing how create_dataframe adds rows to the dataframe. Now as it iterates through the raw files, and libraries within those raw files, it will grab the specific raw file copy (which contains the library specific sequence_file and sequence_file_set information), and add that for the library, instead of just the general raw file object.