### PR TITLE
Replace the previous Claude review instead of stacking a new one

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -59,6 +59,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Run github-pr-review skill
+        id: claude
         uses: anthropics/claude-code-action@v1
         env:
           GH_TOKEN: ${{ github.token }}
@@ -99,8 +100,19 @@ jobs:
             --max-turns 80
             --allowedTools "Read,Write,Grep,Glob,Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh api:*),Bash(git show:*),Bash(git log:*),Bash(git diff:*)"
 
+      # claude-code-action refuses to run when this file differs from the copy on
+      # the default branch - a guard against a PR rewriting the review workflow to
+      # leak secrets - and it still exits success when it does. That is every PR
+      # that edits this workflow, so treat it as a skip, not a missing review.
+      # execution_file is set only when Claude actually ran.
+      - name: Note the skipped review
+        if: steps.claude.outputs.execution_file == ''
+        run: |
+          echo "::notice::Claude Code skipped this run: this workflow file differs from the copy on ${{ github.event.repository.default_branch }}. Expected on PRs that edit the workflow; it resolves once they merge. No review was posted and none were deleted."
+
       - name: Post the new review
         id: post
+        if: steps.claude.outputs.execution_file != ''
         env:
           GH_TOKEN: ${{ github.token }}
         run: |

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -33,7 +33,11 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha }}
-          fetch-depth: 1
+          # Full history, not a depth-1 snapshot. A shallow checkout leaves the
+          # reviewer on a detached HEAD with one commit and no base branch, so
+          # `git log` and any `origin/<base>...HEAD` diff fail and it can only
+          # ever see the diff hunks - never the code they changed.
+          fetch-depth: 0
 
       # Snapshot the stale reviews *before* the new one is posted. Deleting only
       # this pre-existing set means a failed review never leaves the PR with no
@@ -69,6 +73,12 @@ jobs:
             out in the current working directory. Use the REPO and PR NUMBER above
             for the skill's `gh pr view` and `gh pr diff` calls.
 
+            The checkout has full history but is on a detached HEAD, so a bare
+            branch name will not resolve. Where the skill says `git show
+            <headRef>:<path>`, use `git show HEAD:<path>` or just Read the file.
+            To see the pre-change state of the code, diff against the remote-
+            tracking ref: `git diff origin/${{ github.event.pull_request.base.ref }}...HEAD`.
+
             IMPORTANT OVERRIDE: this run is non-interactive. The skill says to
             present the review and wait to be asked before posting. Do NOT wait,
             and do NOT post anything yourself. Instead, write the finished review
@@ -80,10 +90,14 @@ jobs:
             review --approve` or `gh pr review --request-changes` - do not submit
             any formal approve/request-changes review. Approving or blocking the
             PR is always a human decision.
+          # max-turns: a large PR burns turns fast, since the reviewer reads the
+          # diff and then opens each file it touches to check the call sites.
+          # Running out means no review.md, which fails the job - so a too-low
+          # cap costs the whole review, not just its tail.
           claude_args: |
-            --model claude-sonnet-5
-            --max-turns 40
-            --allowedTools "Read,Write,Grep,Glob,Bash(gh pr view:*),Bash(gh pr diff:*),Bash(git show:*)"
+            --model claude-opus-5
+            --max-turns 80
+            --allowedTools "Read,Write,Grep,Glob,Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh api:*),Bash(git show:*),Bash(git log:*),Bash(git diff:*)"
 
       - name: Post the new review
         id: post

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -8,6 +8,12 @@ concurrency:
   group: claude-pr-review-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
+env:
+  # Hidden marker stamped as the first line of every review Claude posts. It is
+  # how a later run recognises its own stale reviews without touching comments
+  # written by humans or by other workflows.
+  REVIEW_MARKER: "<!-- claude-pr-review -->"
+
 jobs:
   review:
     # Only review PRs from branches within this repo; skip PRs opened from forks
@@ -18,6 +24,9 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
+      # Comments on a PR are issue comments, and deleting one needs issues:write
+      # even though creating it only needs pull-requests:write.
+      issues: write
       id-token: write
     steps:
       - name: Check out the PR branch
@@ -25,6 +34,25 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 1
+
+      # Snapshot the stale reviews *before* the new one is posted. Deleting only
+      # this pre-existing set means a failed review never leaves the PR with no
+      # feedback at all, and the new comment can't delete itself.
+      - name: Find superseded Claude reviews
+        id: previous
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          ids=$(gh api \
+            "repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments" \
+            --paginate \
+            --jq '.[] | select(.user.type == "Bot") | select(.body | startswith(env.REVIEW_MARKER)) | .id')
+          echo "Superseded review comments: ${ids:-none}"
+          {
+            echo "ids<<STALE_EOF"
+            echo "$ids"
+            echo "STALE_EOF"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Run github-pr-review skill
         uses: anthropics/claude-code-action@v1
@@ -42,18 +70,44 @@ jobs:
             for the skill's `gh pr view` and `gh pr diff` calls.
 
             IMPORTANT OVERRIDE: this run is non-interactive. The skill says to
-            present the review and wait to be asked before posting. Do NOT wait.
-            After you produce the review, write it to review.md, then post it
-            yourself as a single top-level PR comment:
+            present the review and wait to be asked before posting. Do NOT wait,
+            and do NOT post anything yourself. Instead, write the finished review
+            to a file named review.md in the current working directory. A later
+            workflow step posts that file to the PR for you.
 
-                gh pr comment <PR NUMBER above> --body-file review.md
-
-            Post only the code review (not the PR description). Do not edit the PR
-            body. Never run `gh pr review --approve` or `gh pr review
-            --request-changes` - do not submit any formal approve/request-changes
-            review; a plain comment only. Approving or blocking the PR is always a
-            human decision.
+            Write only the code review to review.md (not the PR description). Do
+            not edit the PR body, and do not comment on the PR. Never run `gh pr
+            review --approve` or `gh pr review --request-changes` - do not submit
+            any formal approve/request-changes review. Approving or blocking the
+            PR is always a human decision.
           claude_args: |
             --model claude-sonnet-5
             --max-turns 40
-            --allowedTools "Read,Write,Grep,Glob,Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr comment:*),Bash(git show:*)"
+            --allowedTools "Read,Write,Grep,Glob,Bash(gh pr view:*),Bash(gh pr diff:*),Bash(git show:*)"
+
+      - name: Post the new review
+        id: post
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if [ ! -s review.md ]; then
+            echo "::error::Claude produced no review.md; leaving the existing review comments in place."
+            exit 1
+          fi
+          { printf '%s\n\n' "$REVIEW_MARKER"; cat review.md; } > review-body.md
+          gh pr comment "${{ github.event.pull_request.number }}" \
+            --repo "${{ github.repository }}" \
+            --body-file review-body.md
+
+      # Runs only once the replacement is safely posted.
+      - name: Delete superseded reviews
+        if: steps.post.outcome == 'success' && steps.previous.outputs.ids != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+          STALE_IDS: ${{ steps.previous.outputs.ids }}
+        run: |
+          printf '%s\n' "$STALE_IDS" | while read -r id; do
+            [ -n "$id" ] || continue
+            echo "Deleting superseded review comment $id"
+            gh api -X DELETE "repos/${{ github.repository }}/issues/comments/$id"
+          done

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -20,7 +20,10 @@ jobs:
     # (fork PRs don't get access to repo secrets, so the review would fail anyway).
     if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    # An opus review with up to 80 turns over a large diff needs room. A job
+    # timeout kills the run before the review is posted, so it costs the whole
+    # review and reports only an opaque red X.
+    timeout-minutes: 30
     permissions:
       contents: read
       pull-requests: write
@@ -38,6 +41,11 @@ jobs:
           # `git log` and any `origin/<base>...HEAD` diff fail and it can only
           # ever see the diff hunks - never the code they changed.
           fetch-depth: 0
+          # But fetch history without blob contents. This repo carries ~95 MB
+          # .h5ad fixtures across 47 branches, so a plain fetch-depth: 0 pulls
+          # 2.5 GB and took 8m24s of a 15-minute job. Blobless is ~18s and keeps
+          # every command above working; blobs are fetched on demand.
+          filter: blob:none
 
       # Snapshot the stale reviews *before* the new one is posted. Deleting only
       # this pre-existing set means a failed review never leaves the PR with no


### PR DESCRIPTION
Every push to an open PR triggers another Claude review, so a PR under active development accumulates a long column of near-identical comments and the current feedback ends up buried. This makes each run clean up after the last one, leaving exactly one Claude review on a PR — always the latest.

Nothing could clean those up before: Claude posted the comment itself, with no way for a later run to tell its own prior review from a human comment or from the test-suite workflow's output.

While in here, three limits were keeping the review shallower than the skill assumes — see *Reviewer capability*.

## What changed

**Replacing the review**

- Stamp every review with a hidden `<!-- claude-pr-review -->` first line — invisible in rendered markdown, and the handle a later run uses to find its own past reviews.
- Move posting from Claude to the workflow, so the body is built deterministically. `Bash(gh pr comment:*)` is dropped from `allowedTools`, and the prompt now tells Claude to write `review.md` and post nothing.
- Add a first step that snapshots the marked comments already on the PR, and a final step that deletes that snapshot once the replacement is posted.
- Add `issues: write`.

**Reviewer capability**

- `fetch-depth: 1` → `0`, `filter: blob:none`. A shallow checkout left the job on a detached HEAD holding one commit with no base branch, so `git show <headRef>:<path>` — which [SKILL.md:46](.claude/skills/github-pr-review/SKILL.md) prescribes for context the diff cannot supply — failed outright, as did `git log` and any base diff. The reviewer could only see the hunks, never the code around them. The blob filter matters: this repo carries ~95 MB `.h5ad` fixtures across 47 branches, so plain `fetch-depth: 0` pulls 2.5 GB and measured **8m24s**; blobless is **~18s** with every command still working.
- `claude-sonnet-5` → `claude-opus-5`. The review runs once per push, and that is where a subtle defect is cheapest to catch.
- `--max-turns` 40 → 80, and `timeout-minutes` 15 → 30. A large PR spends turns reading the diff then opening each file it touches. Both caps are fatal rather than degrading: running out of either means no `review.md` and no posted review.
- Allow `gh api`, `git log`, `git diff`, which the wider history makes useful.
- The prompt now says to use `git show HEAD:<path>` and `git diff origin/<base>...HEAD`, because the checkout stays detached even with full history, so a bare branch name still will not resolve.

## Notes for the reviewer

**Ordering is deliberate.** Post-then-delete, against the id list collected *before* the review runs. So the new comment can never delete itself, and a failed review leaves the old one in place rather than clearing the PR's only feedback. A missing or empty `review.md` fails the job loudly and deletes nothing.

**Why `issues: write`.** Comments on a PR are issue comments under the hood, and deleting one needs that scope even though creating it only needs `pull-requests: write`. Without it the delete step alone would 403.

**Why delete-and-repost rather than one sticky comment edited in place.** Editing a comment sends no notification, so a sticky review would update silently and reviewers would miss new findings.

**Selection is deliberately narrow** — the marker *plus* a `Bot` author. Verified against sample API payloads that it picks only prior Claude reviews and leaves alone: human comments, the `tests.yml` bot comment, dependabot, and a human comment that merely quotes the marker mid-body (`startswith`, not `contains`). Filtering on `.user.type` rather than a hardcoded login keeps it working if `github.token` is later swapped for a PAT or app token.

**The skip guard.** `claude-code-action` refuses to run when this workflow file differs from the copy on the default branch — a guard against a PR rewriting the review workflow to leak secrets — and it still exits `success` when it skips. Posting is therefore gated on the action's `execution_file` output, set only when Claude actually ran, with a notice explaining the skip. Without that gate every PR touching this workflow fails red, and a failure that fires on a whole predictable class of PRs is one people learn to ignore.

## Verification

**This PR cannot review itself.** That same validation gate means `claude-code-action` skips any PR editing its own workflow, so the replace behaviour is not exercisable here — it becomes testable on the next unrelated PR after this merges. The action's log says as much: *"your workflow will begin working once you merge your PR."*

Confirmed on a real run (`450e080`): the action skipped, `execution_file` was empty, the notice fired, post and delete both skipped, job green. So the skip guard itself is observed working, not merely inferred.

Checked locally: the marked-comment selector against sample API payloads; the multiline `GITHUB_OUTPUT` heredoc round-trip; the first-run case with no prior review skipping deletion cleanly; all three checkout configurations reproduced against the real remote to compare capability and cost; and that every non-blank line of `claude_args` parses as a flag.

Still unverified until the first real run after merge: the delete step, which needs live comment ids and the `issues: write` scope.

One caveat once this merges: an open PR that already carries an unmarked legacy Claude comment is invisible to the new selector, so that one comment needs deleting by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
